### PR TITLE
Fixed some small parsing issues

### DIFF
--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -149,7 +149,7 @@ class GimmeAWSCreds(object):
 
         # check if write_aws_creds is true if so
         # get the profile name and write out the file
-        if conf_dict['write_aws_creds']:
+        if str(conf_dict['write_aws_creds']) == 'True':
             print('writing to ', self.AWS_CONFIG)
             # set the profile name
             if conf_dict['cred_profile'] == 'default':

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -139,6 +139,8 @@ class Config(object):
         # if write_aws_creds is True get the profile name
         if config_dict['write_aws_creds'] is True:
             config_dict['cred_profile'] = self.get_cred_profile(cred_profile_default)
+        else:
+            config_dict['cred_profile'] = cred_profile_default
         config_dict['aws_appname'] = self.get_aws_appname(aws_appname_default)
         config_dict['aws_rolename'] = self.get_aws_rolename(aws_rolename_default)
         config_dict['cerberus_url'] = self.get_cerberus_url(cerberus_url_default)


### PR DESCRIPTION
If someone set the option to not write out credentials to the
.aws/credentials file then the resulting config file would be written in
a state that is not parsable, which would throw errors.
Addtionally fixed a small parsing issue with reading a value from the
config file.