### PR TITLE
Configuration Profiles and AWS Credential Profile Aliasing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,99 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# IntelliJ IDE
+.idea/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ With gimme-aws-creds all you need to know is your username, password, Okta url a
 Python 3
 
 ### Optional
-[Cerberus](http://engineering.nike.com/cerberus/) can be used for storing the Okta API key. gimme-aws-creds uses the [Cerberus Python Client](https://github.com/Nike-Inc/cerberus-python-client) for interacting with Cerberus. It would be very easy to drop something else besides Cerberus to retrieve your API key. Otherwise, you can set the OKTA_API_KEY environment variable.
+[Cerberus](http://engineering.nike.com/cerberus/) can be used for storing the Okta API key. gimme-aws-creds uses the [Cerberus Python Client](https://github.com/Nike-Inc/cerberus-python-client) for interacting with Cerberus. It would be very easy to drop something else besides Cerberus to retrieve your API key. Otherwise, you can set the `OKTA_API_KEY` environment variable.
 
 
 ## Installation
@@ -35,13 +35,18 @@ To set-up the configuration run:
 gimme-aws-creds --configure
 ```
 
-A configuration wizard will prompt you to enter the necessary configuration parameters for the tool to run, the only one that is required is the idp_entry_url. The configuration file is written to ~/.okta_aws_login_config.
+You can also set up configuration profiles, useful if you have multiple accounts you need credentials for:
+```bash
+gimme-aws-creds --configure --profile profileName
+```
 
-- idp_entry_url - This is your Okta entry url, which is typically something like https://companyname.okta.com.
-- write_aws_creds - y or no - If yes, the AWS credentials will be written to ~/.aws/credentials
-- cred_profile - If writting to the AWS cred file, this sets the name of the profile
-- aws_appname - This is optional. The Okta AWS App name, which has the role you want to assume
-- aws_rolename - This is optional. The name of the role you want temporary AWS credentials for
+A configuration wizard will prompt you to enter the necessary configuration parameters for the tool to run, the only one that is required is the `idp_entry_url`. The configuration file is written to `~/.okta_aws_login_config`.
+
+- idp_entry_url - This is your Okta entry url, which is typically something like `https://companyname.okta.com`.
+- write_aws_creds - y or no - If yes, the AWS credentials will be written to `~/.aws/credentials`.
+- cred_profile - If writing to the AWS cred file, this sets the name of the profile.
+- aws_appname - This is optional. The Okta AWS App name, which has the role you want to assume.
+- aws_rolename - This is optional. The name of the role you want temporary AWS credentials for.
 - cerberus_url - This is optional. This is the URL of your Cerberus instance, which can be use to store your Okta API Key.
 
 
@@ -69,15 +74,21 @@ export AWS_ACCESS_KEY_ID=AQWERTYUIOP
 export AWS_SECRET_ACCESS_KEY=T!#$JFLOJlsoddop1029405-P
 ```
 
-The username and password you are prompted for are the ones you login to Okta with. You can predefine your username by setting the OKTA_USERNAME environment variable.
+You can run a specific configuration profile with the `--profile` flag:
+
+```bash
+$ ./gimme-aws-creds --profile profileName
+```
+
+The username and password you are prompted for are the ones you login to Okta with. You can predefine your username by setting the `OKTA_USERNAME` environment variable.
 
 If you are using Cerberus, it is assumed you use the same username and password for it. If MFA is enabled you will be prompted for it.
 
 If you have not configure an Okta App or Role, you will prompted to select one.
 
-If all goes well you will get your temporary AWS access, secret key and token, these will either be written to stdout or ~/.aws/credentials.
+If all goes well you will get your temporary AWS access, secret key and token, these will either be written to stdout or `~/.aws/credentials`.
 
-You can always run ```gimme-aws-creds --help``` for all the available options.
+You can always run `gimme-aws-creds --help` for all the available options.
 
 ## Running Tests
 

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -18,7 +18,6 @@ from os.path import expanduser
 
 # extras
 import boto3
-import requests
 
 # local imports
 from gimme_aws_creds.config import Config
@@ -43,9 +42,11 @@ class GimmeAWSCreds(object):
                         username can also be set via the OKTA_USERNAME env
                         variable. If not provided you will be prompted to
                         enter a username.
-         --configure, -c  If set, will prompt user for configuration
-                          parameters and then exit.
-         --profile, -p  If set, the specified configuration profile will
+         --configure, -c
+                        If set, will prompt user for configuration
+                        parameters and then exit.
+         --profile PROFILE, -p PROFILE
+                        If set, the specified configuration profile will
                         be used instead of the default profile.
 
         Config Options:
@@ -71,9 +72,11 @@ class GimmeAWSCreds(object):
         if os.path.exists(creds_dir) is False:
             os.makedirs(creds_dir)
         config = configparser.RawConfigParser()
+
         # Read in the existing config file if it exists
         if os.path.isfile(self.AWS_CONFIG):
             config.read(self.AWS_CONFIG)
+
         # Put the credentials into a saml specific section instead of clobbering
         # the default credentials
         if not config.has_section(profile):
@@ -81,6 +84,7 @@ class GimmeAWSCreds(object):
         config.set(profile, 'aws_access_key_id', access_key)
         config.set(profile, 'aws_secret_access_key', secret_key)
         config.set(profile, 'aws_session_token', token)
+
         # Write the updated config file
         with open(self.AWS_CONFIG, 'w+') as configfile:
             config.write(configfile)
@@ -94,6 +98,13 @@ class GimmeAWSCreds(object):
             SAMLAssertion=assertion,
             DurationSeconds=duration)
         return response['Credentials']
+
+    @staticmethod
+    def mfa_callback(message, user_input=True):
+        if user_input:
+            return input(message + ': ')
+        else:
+            print(message)
 
     def run(self):
         """ Pulling it all together to make the CLI """
@@ -109,45 +120,30 @@ class GimmeAWSCreds(object):
         config.get_user_creds()
         idp_entry_url = conf_dict['idp_entry_url'] + '/api/v1'
 
-        # this assumes you are using a cerberus backend
-        # to store your okta api key, and the key name
-        # is the hostname for your okta env
-        # otherwise set OKTA_API_KEY env variable
-        api_key = config.get_okta_api_key()
-
         # create otka client
-        okta = OktaClient(api_key, idp_entry_url)
-
-        # get okta login json response
-        resp = okta.get_login_response(config.username, config.password)
+        okta = OktaClient(idp_entry_url, config.username, config.password)
 
         # check to see if appname and rolename are set
         # in the config, if not give user a selection to pick from
         if not conf_dict['aws_appname']:
-            aws_appname = okta.get_app(resp)
+            aws_appname = okta.get_app()
         else:
             aws_appname = conf_dict['aws_appname']
         if not conf_dict['aws_rolename']:
-            aws_rolename = okta.get_role(resp, aws_appname)
+            aws_rolename = okta.get_role(aws_appname)
         else:
             aws_rolename = conf_dict['aws_rolename']
 
         # get the applinks available to the user
-        app_url = okta.get_app_url(resp, aws_appname)
+        app_url = okta.get_app_url(aws_appname)
 
         # Get the the identityProviderArn from the aws app
         self.idp_arn = okta.get_idp_arn(app_url['appInstanceId'])
 
         # Get the role ARNs
-        self.role_arn = okta.get_role_arn(
-            app_url['linkUrl'], resp['sessionToken'], aws_rolename)
+        self.role_arn = okta.get_role_arn(app_url['linkUrl'], aws_rolename)
 
-        # get a new token for aws_creds
-        login_resp = okta.get_login_response(config.username, config.password)
-        resp2 = requests.get(
-            app_url['linkUrl'] + '/?sessionToken='
-            + login_resp['sessionToken'], verify=True)
-        assertion = okta.get_saml_assertion(resp2)
+        assertion = okta.get_saml_assertion(app_url['linkUrl'])
         aws_creds = self.get_sts_creds(assertion)
 
         # check if write_aws_creds is true if so
@@ -160,11 +156,9 @@ class GimmeAWSCreds(object):
             elif conf_dict['cred_profile'] == 'role':
                 profile_name = aws_rolename
             else:
-                # To prevent the script from bombing out.
-                print('Invalid cred_profile setting in configuration. "'
-                      'Storing AWS credentials under "temp" profile name.')
-                profile_name = 'temp'
-            # write out the AWS Config file
+                profile_name = conf_dict['cred_profile']
+
+            # Write out the AWS Config file
             self.write_aws_creds(
                 profile_name,
                 aws_creds['AccessKeyId'],
@@ -172,7 +166,7 @@ class GimmeAWSCreds(object):
                 aws_creds['SessionToken']
             )
         else:
-            # print out creds
+            # Print out temporary AWS credentials.
             print("export AWS_ACCESS_KEY_ID=" + aws_creds['AccessKeyId'])
             print("export AWS_SECRET_ACCESS_KEY=" + aws_creds['SecretAccessKey'])
             print("export AWS_SESSION_TOKEN=" + aws_creds['SessionToken'])

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and* limitations
 # standard imports
 import configparser
 import os
-from os.path import expanduser
 import sys
+from os.path import expanduser
 
 # extras
 import boto3
@@ -23,6 +23,7 @@ import requests
 # local imports
 from gimme_aws_creds.config import Config
 from gimme_aws_creds.okta import OktaClient
+
 
 class GimmeAWSCreds(object):
     """
@@ -44,6 +45,8 @@ class GimmeAWSCreds(object):
                         enter a username.
          --configure, -c  If set, will prompt user for configuration
                           parameters and then exit.
+         --profile, -p  If set, the specified configuration profile will
+                        be used instead of the default profile.
 
         Config Options:
            idp_entry_url = Okta URL
@@ -96,7 +99,7 @@ class GimmeAWSCreds(object):
         """ Pulling it all together to make the CLI """
         config = Config()
         config.get_args()
-        #Create/Update config when configure arg set
+        # Create/Update config when configure arg set
         if config.configure is True:
             config.update_config_file()
             sys.exit()
@@ -156,6 +159,11 @@ class GimmeAWSCreds(object):
                 profile_name = 'default'
             elif conf_dict['cred_profile'] == 'role':
                 profile_name = aws_rolename
+            else:
+                # To prevent the script from bombing out.
+                print('Invalid cred_profile setting in configuration. "'
+                      'Storing AWS credentials under "temp" profile name.')
+                profile_name = 'temp'
             # write out the AWS Config file
             self.write_aws_creds(
                 profile_name,

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -120,11 +120,14 @@ class GimmeAWSCreds(object):
     def _get_sts_creds(self, assertion, duration=3600):
         """ using the assertion and arns return aws sts creds """
         client = boto3.client('sts')
+
         response = client.assume_role_with_saml(
             RoleArn=self.role_arn,
             PrincipalArn=self.idp_arn,
             SAMLAssertion=assertion,
-            DurationSeconds=duration)
+            DurationSeconds=duration
+        )
+
         return response['Credentials']
 
     def run(self):
@@ -152,6 +155,7 @@ class GimmeAWSCreds(object):
             idp_entry_url,
             cerberus_url=conf_dict['cerberus_url']
         )
+
         okta = OktaClient(idp_entry_url, api_key, config.username, config.password)
 
         # check to see if appname and rolename are set

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -15,11 +15,14 @@ import configparser
 import os
 import sys
 from os.path import expanduser
-
 # extras
-import boto3
+from urllib.parse import urlparse
 
+import boto3
 # local imports
+from cerberus.client import CerberusClient
+from requests.exceptions import MissingSchema
+
 from gimme_aws_creds.config import Config
 from gimme_aws_creds.okta import OktaClient
 
@@ -64,8 +67,32 @@ class GimmeAWSCreds(object):
         self.idp_arn = None
         self.role_arn = None
 
+    @staticmethod
+    def _get_okta_api_key(username, password, idp_entry_url, cerberus_url=None):
+        """returns the Okta API key from
+        env var OKTA_API_KEY or from cerberus.
+        This assumes your SDB is named Okta and
+        your Vault path ends is api_key"""
+        if os.environ.get("OKTA_API_KEY") is not None:
+            secret = os.environ.get("OKTA_API_KEY")
+        else:
+            if cerberus_url == ('' or None):
+                print('No Cerberus URL in configuration or OKTA_API_KEY environmental variable; unable to continue.')
+                sys.exit(1)
+
+            try:
+                cerberus = CerberusClient(cerberus_url, username, password)
+                path = cerberus.get_sdb_path('Okta')
+                key = urlparse(idp_entry_url).netloc
+                secret = cerberus.get_secret(path + '/api_key', key)
+            except MissingSchema:
+                print('No Cerberus URL in configuration or OKTA_API_KEY environmental variable; unable to continue.')
+                sys.exit(1)
+
+        return secret
+
     #  this is modified code from https://github.com/nimbusscale/okta_aws_login
-    def write_aws_creds(self, profile, access_key, secret_key, token):
+    def _write_aws_creds(self, profile, access_key, secret_key, token):
         """ Writes the AWS STS token into the AWS credential file"""
         # Check to see if the aws creds path exists, if not create it
         creds_dir = os.path.dirname(self.AWS_CONFIG)
@@ -81,6 +108,7 @@ class GimmeAWSCreds(object):
         # the default credentials
         if not config.has_section(profile):
             config.add_section(profile)
+
         config.set(profile, 'aws_access_key_id', access_key)
         config.set(profile, 'aws_secret_access_key', secret_key)
         config.set(profile, 'aws_session_token', token)
@@ -89,7 +117,7 @@ class GimmeAWSCreds(object):
         with open(self.AWS_CONFIG, 'w+') as configfile:
             config.write(configfile)
 
-    def get_sts_creds(self, assertion, duration=3600):
+    def _get_sts_creds(self, assertion, duration=3600):
         """ using the assertion and arns return aws sts creds """
         client = boto3.client('sts')
         response = client.assume_role_with_saml(
@@ -98,13 +126,6 @@ class GimmeAWSCreds(object):
             SAMLAssertion=assertion,
             DurationSeconds=duration)
         return response['Credentials']
-
-    @staticmethod
-    def mfa_callback(message, user_input=True):
-        if user_input:
-            return input(message + ': ')
-        else:
-            print(message)
 
     def run(self):
         """ Pulling it all together to make the CLI """
@@ -118,10 +139,20 @@ class GimmeAWSCreds(object):
         # get the config dict
         conf_dict = config.get_config_dict()
         config.get_user_creds()
+
+        if conf_dict['idp_entry_url'] in [None, '']:
+            print('No IDP entry URL in configuration.  Try running --config again.')
+
         idp_entry_url = conf_dict['idp_entry_url'] + '/api/v1'
 
         # create otka client
-        okta = OktaClient(idp_entry_url, config.username, config.password)
+        api_key = self._get_okta_api_key(
+            config.username,
+            config.password,
+            idp_entry_url,
+            cerberus_url=conf_dict['cerberus_url']
+        )
+        okta = OktaClient(idp_entry_url, api_key, config.username, config.password)
 
         # check to see if appname and rolename are set
         # in the config, if not give user a selection to pick from
@@ -129,6 +160,7 @@ class GimmeAWSCreds(object):
             aws_appname = okta.get_app()
         else:
             aws_appname = conf_dict['aws_appname']
+
         if not conf_dict['aws_rolename']:
             aws_rolename = okta.get_role(aws_appname)
         else:
@@ -144,22 +176,22 @@ class GimmeAWSCreds(object):
         self.role_arn = okta.get_role_arn(app_url['linkUrl'], aws_rolename)
 
         assertion = okta.get_saml_assertion(app_url['linkUrl'])
-        aws_creds = self.get_sts_creds(assertion)
+        aws_creds = self._get_sts_creds(assertion)
 
         # check if write_aws_creds is true if so
         # get the profile name and write out the file
         if str(conf_dict['write_aws_creds']) == 'True':
             print('writing to ', self.AWS_CONFIG)
             # set the profile name
-            if conf_dict['cred_profile'] == 'default':
+            if conf_dict['cred_profile'].lower() == 'default':
                 profile_name = 'default'
-            elif conf_dict['cred_profile'] == 'role':
+            elif conf_dict['cred_profile'].lower() == 'role':
                 profile_name = aws_rolename
             else:
                 profile_name = conf_dict['cred_profile']
 
             # Write out the AWS Config file
-            self.write_aws_creds(
+            self._write_aws_creds(
                 profile_name,
                 aws_creds['AccessKeyId'],
                 aws_creds['SecretAccessKey'],

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -113,7 +113,7 @@ class Config(object):
         """
         config = configparser.ConfigParser()
         if self.configure:
-            self.conf_profile = self.get_conf_profile_name(self.conf_profile)
+            self.conf_profile = self._get_conf_profile_name(self.conf_profile)
 
         defaults = {
             'idp_entry_url': '',
@@ -137,16 +137,16 @@ class Config(object):
 
         # Prompt user for config details and store in config_dict
         config_dict = {
-            'idp_entry_url': self.get_idp_entry(defaults['idp_entry_url']),
-            'write_aws_creds': self.get_write_aws_creds(defaults['write_aws_creds']),
-            'aws_appname': self.get_aws_appname(defaults['aws_appname']),
-            'aws_rolename': self.get_aws_rolename(defaults['aws_rolename']),
-            'cerberus_url': self.get_cerberus_url(defaults['cerberus_url'])
+            'idp_entry_url': self._get_idp_entry(defaults['idp_entry_url']),
+            'write_aws_creds': self._get_write_aws_creds(defaults['write_aws_creds']),
+            'aws_appname': self._get_aws_appname(defaults['aws_appname']),
+            'aws_rolename': self._get_aws_rolename(defaults['aws_rolename']),
+            'cerberus_url': self._get_cerberus_url(defaults['cerberus_url'])
         }
 
         # If write_aws_creds is True get the profile name
         if config_dict['write_aws_creds'] is True:
-            config_dict['cred_profile'] = self.get_cred_profile(defaults['cred_profile'])
+            config_dict['cred_profile'] = self._get_cred_profile(defaults['cred_profile'])
         else:
             config_dict['cred_profile'] = defaults['cred_profile']
 
@@ -157,14 +157,14 @@ class Config(object):
         with open(self.OKTA_CONFIG, 'w') as configfile:
             config.write(configfile)
 
-    def get_idp_entry(self, default_entry):
+    def _get_idp_entry(self, default_entry):
         """ Get and validate idp_entry_url """
         print("Enter the IDP Entry URL. This is https://something.okta[preview].com")
         idp_entry_url_valid = False
         idp_entry_url = default_entry
 
         while idp_entry_url_valid is False:
-            idp_entry_url = self.get_user_input("IDP Entry URL", default_entry)
+            idp_entry_url = self._get_user_input("IDP Entry URL", default_entry)
             # Validate that idp_entry_url is a well formed okta URL
             url_parse_results = urlparse(idp_entry_url)
 
@@ -175,7 +175,7 @@ class Config(object):
 
         return idp_entry_url
 
-    def get_write_aws_creds(self, default_entry):
+    def _get_write_aws_creds(self, default_entry):
         """ Option to write to the ~/.aws/credentials or to stdour"""
         print("Do you want to write the temporary AWS to ~/.aws/credentials?"
               "\nIf no, the credentials will be written to stdout."
@@ -183,7 +183,7 @@ class Config(object):
         write_aws_creds = None
         while write_aws_creds is not True and write_aws_creds is not False:
             default_entry = 'y' if default_entry is True else 'n'
-            answer = self.get_user_input("Write AWS Credentials", default_entry)
+            answer = self._get_user_input("Write AWS Credentials", default_entry)
             answer = answer.lower()
 
             if answer == 'y':
@@ -195,55 +195,50 @@ class Config(object):
 
         return write_aws_creds
 
-    def get_cred_profile(self, default_entry):
+    def _get_cred_profile(self, default_entry):
         """sets the aws credential profile name"""
-        print("The AWS credential profile defines which profile is used to store the temp AWS "
-              "creds.\nIf set to 'role' then a new profile will be created "
-              "matching the role name assumed by the user.\nIf set to 'default' "
-              "then the temp creds will be stored in the default profile")
-        cred_profile_valid = False
-        cred_profile = None
+        print("The AWS credential profile defines which profile is used to store the temp AWS creds.\n"
+              "If set to 'role' then a new profile will be created matching the role name assumed by the user.\n"
+              "If set to 'default' then the temp creds will be stored in the default profile\n"
+              "If set to any other value, the name of the profile will match that value.")
 
-        while cred_profile_valid is False:
-            cred_profile = self.get_user_input("AWS Credential Profile", default_entry)
+        cred_profile = self._get_user_input("AWS Credential Profile", default_entry)
+
+        if cred_profile.lower() in ['default', 'role']:
             cred_profile = cred_profile.lower()
-            # validate if either role or default was entered
-            if cred_profile in ["default", "role"]:
-                cred_profile_valid = True
-            else:
-                print("AWS credential profile name must be either default or role.")
+
         return cred_profile
 
-    def get_aws_appname(self, default_entry):
+    def _get_aws_appname(self, default_entry):
         """ Get Okta AWS App name """
         print("Enter the AWS Okta App Name."
               "\nThis is optional, you can select the App when you run the CLI.")
-        aws_appname = self.get_user_input("AWS App Name", default_entry)
+        aws_appname = self._get_user_input("AWS App Name", default_entry)
         return aws_appname
 
-    def get_aws_rolename(self, default_entry):
+    def _get_aws_rolename(self, default_entry):
         """ Get the AWS Role name"""
         print("Enter the AWS role name you want credentials for."
               "\nThis is optional, you can select the role when you run the CLI.")
-        aws_rolename = self.get_user_input("AWS Role Name", default_entry)
+        aws_rolename = self._get_user_input("AWS Role Name", default_entry)
         return aws_rolename
 
-    def get_cerberus_url(self, default_entry):
+    def _get_cerberus_url(self, default_entry):
         """ Get and validate cerberus url - this is optional"""
-        print("If you are using Cerberus to store your Okta API Key, this is optional."
+        print("If you are using Cerberus to store your Okta API Key, this is optional.\n"
               "Enter your Cerberus URL.")
-        cerberus_url = self.get_user_input("Cerberus URL", default_entry)
+        cerberus_url = self._get_user_input("Cerberus URL", default_entry)
         return cerberus_url
 
-    def get_conf_profile_name(self, default_entry):
+    def _get_conf_profile_name(self, default_entry):
         """Get and validate configuration profile name. [Optional]"""
         print("If you'd like to assign this configuration to a specific profile instead of to the default profile, "
               "specify the name of the profile.  This is optional.")
-        conf_profile = self.get_user_input("Configuration Profile Name", default_entry)
+        conf_profile = self._get_user_input("Configuration Profile Name", default_entry)
         return conf_profile
 
     @staticmethod
-    def get_user_input(message, default=None):
+    def _get_user_input(message, default=None):
         """formats message to include default and then prompts user for input
         via keyboard with message. Returns user's input or if user doesn't
         enter input will return the default."""

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -9,13 +9,14 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and* limitations under the License.*
 """
-import sys
 import base64
 import json
+import sys
 import xml.etree.ElementTree as ET
-import requests
 
+import requests
 from bs4 import BeautifulSoup
+
 
 class OktaClient(object):
     """
@@ -29,11 +30,11 @@ class OktaClient(object):
 
     def get_headers(self):
         """sets the default header"""
-        headers = {'Accept' : 'application/json',
-                   'Content-Type' : 'application/json',
-                   'Authorization' : 'SSWS ' + self.okta_api_key}
+        headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Authorization': 'SSWS ' + self.okta_api_key}
         return headers
-
 
     def get_login_response(self, username, password):
         """ gets the login response from Okta and returns the json response"""

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='gimme aws creds',
-    version='0.1.3',
+    version='0.1.4',
     install_requires=requirements,
     author='Ann Wallace',
     author_email='ann.wallace@nike.com',
@@ -15,4 +15,4 @@ setup(
     packages=find_packages(exclude=('tests', 'docs')),
     test_suite="tests",
     scripts=['bin/gimme-aws-creds'],
-  )
+)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,12 @@
 """Unit tests for gimme_aws_creds.config.Config"""
 import argparse
-
 import unittest
+
 from mock import patch
 from nose.tools import assert_equals
 
 from gimme_aws_creds.config import Config
+
 
 class TestConfig(unittest.TestCase):
     """Class to test Config Class.
@@ -20,7 +21,7 @@ class TestConfig(unittest.TestCase):
         self.config.clean_up()
 
     @patch('argparse.ArgumentParser.parse_args',
-           return_value=argparse.Namespace(username='ann', configure=False))
+           return_value=argparse.Namespace(username='ann', configure=False, profile=None))
     def test_get_args_username(self, mock_arg):
         """Test to make sure username gets returned"""
         self.config.get_args()

--- a/tests/test_okta_client.py
+++ b/tests/test_okta_client.py
@@ -1,6 +1,7 @@
 """Unit tests for gimme_aws_creds.okta.OktaClient"""
 import json
 import unittest
+
 import requests
 from mock import patch
 from nose.tools import (
@@ -11,6 +12,7 @@ from nose.tools import (
 )
 
 from gimme_aws_creds.okta import OktaClient
+
 
 class TestOktaClient(unittest.TestCase):
     """Class to test Okta Client Class.
@@ -31,16 +33,16 @@ class TestOktaClient(unittest.TestCase):
         }
         self.app_links = [
             {
-                "id":"1",
-                "label":"AWS Prod",
-                "linkUrl":"https://example.oktapreview.com/1",
-                "appName":"amazon_aws"
+                "id": "1",
+                "label": "AWS Prod",
+                "linkUrl": "https://example.oktapreview.com/1",
+                "appName": "amazon_aws"
             },
             {
-                "id":"2",
-                "label":"AWS Dev",
-                "linkUrl":"https://example.oktapreview.com/2",
-                "appName":"amazon_aws"
+                "id": "2",
+                "label": "AWS Dev",
+                "linkUrl": "https://example.oktapreview.com/2",
+                "appName": "amazon_aws"
             }
         ]
 
@@ -56,7 +58,7 @@ class TestOktaClient(unittest.TestCase):
 
     def test_get_headers(self):
         """Testing that get_headers returns the expected results"""
-        header = self.client.get_headers()
+        header = self.client._get_headers()
         assert_equals(header['Authorization'], 'SSWS XXXXXX')
 
     @patch('requests.post')
@@ -80,7 +82,7 @@ class TestOktaClient(unittest.TestCase):
             }
         }
         mock_post.return_value = self._mock_response(content=json.dumps(login))
-        response = self.client.get_login_response("username", "password")
+        response = self.client._get_login_response("username", "password")
         assert_dict_equal(response, login)
 
     @patch('requests.get')


### PR DESCRIPTION
Implemented the ability for creating configuration profiles, which are selected using the --profile flag.  Also implemented the ability for users to set their own AWS credential profile aliases, as some role names are long and tedious to type out every time you want to reference the profile.

Also reorganized some of the OktaClient code to create more of a separation of duties for the two classes.

Updated the tests to match the code changes.