### PR TITLE
Keyring storage of Okta password, more useful in bash scripts

### DIFF
--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -202,12 +202,19 @@ class GimmeAWSCreds(object):
                 aws_creds['SessionToken']
             )
         else:
-            # Print out temporary AWS credentials.
-            print("export AWS_ACCESS_KEY_ID=" + aws_creds['AccessKeyId'])
-            print("export AWS_SECRET_ACCESS_KEY=" + aws_creds['SecretAccessKey'])
-            print("export AWS_SESSION_TOKEN=" + aws_creds['SessionToken'])
+            # Print out temporary AWS credentials.  Credentials are printed to stderr to simplify
+            # redirection for use in automated scripts
+            print("export AWS_ACCESS_KEY_ID=" + aws_creds['AccessKeyId'], file=sys.stderr)
+            print("export AWS_SECRET_ACCESS_KEY=" + aws_creds['SecretAccessKey'], file=sys.stderr)
+            print("export AWS_SESSION_TOKEN=" + aws_creds['SessionToken'], file=sys.stderr)
 
         config.clean_up()
 
 if __name__ == '__main__':
-    GimmeAWSCreds().run()
+    try:
+        GimmeAWSCreds().run()
+    except KeyboardInterrupt:
+        try:
+            sys.exit(1)
+        except SystemExit:
+            os._exit(1)

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -12,6 +12,7 @@ See the License for the specific language governing permissions and* limitations
 import argparse
 import configparser
 import getpass
+import keyring
 import os
 import sys
 from os.path import expanduser
@@ -88,14 +89,23 @@ class Config(object):
             username = os.environ.get("OKTA_USERNAME")
         # Otherwise just ask the user
         else:
-            username = input("Email address: ")
-        # Set prompt to include the user name, since username could be set
-        # via OKTA_USERNAME env and user might not remember.
-        passwd_prompt = "Password for {}: ".format(username)
-        password = getpass.getpass(prompt=passwd_prompt)
-        if len(password) == 0:
-            print("Password must be provided.")
-            sys.exit(1)
+            username = self._get_user_input("Email address")
+        # Check to see if the password is available in the keyring
+        password = keyring.get_password('gimme-aws-creds', username)
+        if password is not None:
+            print("Using password from keyring for {}".format(username))
+        else:
+            # Set prompt to include the user name, since username could be set
+            # via OKTA_USERNAME env and user might not remember.
+            passwd_prompt = "Password for {}: ".format(username)
+            password = getpass.getpass(prompt=passwd_prompt)
+            if len(password) == 0:
+                print("Password must be provided.")
+                sys.exit(1)
+            save_password  = self._get_user_input("Do you want to save this password in the keyring?", 'y')
+            if save_password == 'y':
+                keyring.set_password('gimme-aws-creds', username, password)
+                print("Password for {} saved in keyring.".format(username))
         self.username = username
         self.password = password
 
@@ -248,8 +258,9 @@ class Config(object):
         else:
             prompt_message = message + ': '
 
-        user_input = input(prompt_message)
-        print("")
+        # print the prompt with print() rather than input() as input prompts on stderr
+        print(prompt_message, end='')
+        user_input = input()
         if len(user_input) == 0:
             return default
         else:

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -95,6 +95,7 @@ class Config(object):
             password = keyring.get_password('gimme-aws-creds', username)
             working_keyring = True
         except:
+            password = None
             working_keyring = False
         if password is not None:
             print("Using password from keyring for {}".format(username))

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -90,8 +90,9 @@ class Config(object):
         # Otherwise just ask the user
         else:
             username = self._get_user_input("Email address")
-        # Check to see if the password is available in the keyring
-        password = keyring.get_password('gimme-aws-creds', username)
+        # If the OS supports a keyring, check to see if the password is available
+        if keyring.get_keyring() is not None:
+            password = keyring.get_password('gimme-aws-creds', username)
         if password is not None:
             print("Using password from keyring for {}".format(username))
         else:
@@ -102,10 +103,12 @@ class Config(object):
             if len(password) == 0:
                 print("Password must be provided.")
                 sys.exit(1)
-            save_password  = self._get_user_input("Do you want to save this password in the keyring?", 'y')
-            if save_password == 'y':
-                keyring.set_password('gimme-aws-creds', username, password)
-                print("Password for {} saved in keyring.".format(username))
+            # If the OS supports a keyring, offer to save the password
+            if keyring.get_keyring() is not None:
+                save_password = self._get_user_input("Do you want to save this password in the keyring?", 'y')
+                if save_password == 'y':
+                    keyring.set_password('gimme-aws-creds', username, password)
+                    print("Password for {} saved in keyring.".format(username))
         self.username = username
         self.password = password
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ boto3
 bs4
 cerberus-python-client >= 0.2.0
 configparser >= 3.5
+keyring
 mock
 nose
 requests


### PR DESCRIPTION
* Added keyring to store user's Okta password in their keychain/credential vault. This allows the tool to be used in automated scripts with the -p and -u params with a cached password for non-interactive retrieval of AWS credentials.

* Modified the user input method to print the input prompt on stdout rather than stderr. Modified the printing of export statements to print to stderr rather than stdout. These two changes allow for redirecting stderr to a file for cases when you want to capture the credentials for sourcing from the command line without any output cruft.

* Added a keyboard interrupt (ctrl+c) handler to prevent trace output when the user cancels the script.