### PR TITLE
Use gimme_creds_lambda as a proxy for Okta APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
-htmlcov/
+covhtml/
 .tox/
 .coverage
 .coverage.*

--- a/README.md
+++ b/README.md
@@ -35,16 +35,17 @@ To set-up the configuration run:
 gimme-aws-creds --configure
 ```
 
-You can also set up configuration profiles, useful if you have multiple accounts you need credentials for:
+You can also set up different Okta configuration profiles, this useful if you have multiple Okta accounts or environments you need credentials for. You can use the configuration wizard or run:
 ```bash
 gimme-aws-creds --configure --profile profileName
 ```
 
 A configuration wizard will prompt you to enter the necessary configuration parameters for the tool to run, the only one that is required is the `idp_entry_url`. The configuration file is written to `~/.okta_aws_login_config`.
 
+- conf_profile - This sets the Okta configuration profile name, the default is DEFAULT. 
 - idp_entry_url - This is your Okta entry url, which is typically something like `https://companyname.okta.com`.
-- write_aws_creds - y or no - If yes, the AWS credentials will be written to `~/.aws/credentials`.
-- cred_profile - If writing to the AWS cred file, this sets the name of the profile.
+- write_aws_creds - y or n - If yes, the AWS credentials will be written to `~/.aws/credentials` otherwise it will be written to stdout.
+- cred_profile - If writing to the AWS cred file, this sets the name of the AWS credential profile.
 - aws_appname - This is optional. The Okta AWS App name, which has the role you want to assume.
 - aws_rolename - This is optional. The name of the role you want temporary AWS credentials for.
 - cerberus_url - This is optional. This is the URL of your Cerberus instance, which can be use to store your Okta API Key.

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ You can also set up different Okta configuration profiles, this useful if you ha
 gimme-aws-creds --configure --profile profileName
 ```
 
-A configuration wizard will prompt you to enter the necessary configuration parameters for the tool to run, the only one that is required is the `idp_entry_url`. The configuration file is written to `~/.okta_aws_login_config`.
+A configuration wizard will prompt you to enter the necessary configuration parameters for the tool to run, the only one that is required is the `okta_org_url`. The configuration file is written to `~/.okta_aws_login_config`.
 
-- conf_profile - This sets the Okta configuration profile name, the default is DEFAULT. 
-- idp_entry_url - This is your Okta entry url, which is typically something like `https://companyname.okta.com`.
+- conf_profile - This sets the Okta configuration profile name, the default is DEFAULT.
+- okta_org_url - This is your Okta organization url, which is typically something like `https://companyname.okta.com`.
 - write_aws_creds - y or n - If yes, the AWS credentials will be written to `~/.aws/credentials` otherwise it will be written to stdout.
 - cred_profile - If writing to the AWS cred file, this sets the name of the AWS credential profile.
 - aws_appname - This is optional. The Okta AWS App name, which has the role you want to assume.

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -187,8 +187,8 @@ class GimmeAWSCreds(object):
 
         okta_org_url = conf_dict['okta_org_url']
 
-        if conf_dict['embed_link'] in [None, '']:
-            print('No IdP-initiated login URL (embed link) in configuration.  Try running --config again.')
+        if conf_dict['client_id'] in [None, '']:
+            print('No OAuth Client ID in configuration.  Try running --config again.')
 
         if conf_dict['gimme_creds_server'] in [None, '']:
             print('No gimme-creds-server URL in configuration.  Try running --config again.')

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -54,7 +54,9 @@ class GimmeAWSCreds(object):
 
         Config Options:
            okta_org_url = Okta URL
-           embed_link = IdP-initiated login URL for the gimme-creds-server
+           gimme_creds_server = URL of the gimme-creds-server
+           client_id = OAuth Client id for the gimme-creds-server
+           okta_auth_server = Server ID for the OAuth authorization server used by gimme-creds-server
            write_aws_creds = Option to write creds to ~/.aws/credentials
            cred_profile = Use DEFAULT or Role as the profile in ~/.aws/credentials
            aws_appname = (optional) Okta AWS App Name
@@ -108,8 +110,7 @@ class GimmeAWSCreds(object):
 
     def _get_aws_account_info(self, okta_connection, gimme_creds_server_url):
         """ Retrieve the user's AWS accounts from the gimme_creds_server"""
-        api_url = gimme_creds_server_url + '/api/v1/accounts'
-        response = okta_connection.get(api_url)
+        response = okta_connection.get(gimme_creds_server_url)
 
         # Throw an error if we didn't get any accounts back
         if response.json() == []:
@@ -196,18 +197,17 @@ class GimmeAWSCreds(object):
         if config.username is not None:
             okta.set_username(config.username)
 
-        # tokens = okta.auth_oauth('tocqhTv1QcotXrNqnTXg',
-        #     authorization_server='aus9cz9q21TeYIzid0h7',
-        #     access_token=True,
-        #     id_token=False,
-        #     scopes=['openid']
-        # )
-        #
-        # print(tokens)
-        #
-        # sys.exit()
+        # Authenticate with Okta
+        tokens = okta.auth_oauth(conf_dict['client_id'],
+            authorization_server=conf_dict['okta_auth_server'],
+            access_token=True,
+            id_token=False,
+            scopes=['openid']
+        )
 
-        okta.stepup_auth_saml(conf_dict['embed_link'])
+        # Add Access Tokens to Okta-protected requests
+        okta.use_oauth_access_token(True)
+
         print("Authentication Success! Getting AWS Accounts...")
         aws_results = self._get_aws_account_info(okta, conf_dict['gimme_creds_server'])
 

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -44,7 +44,8 @@ class GimmeAWSCreds(object):
                         username can also be set via the OKTA_USERNAME env
                         variable. If not provided you will be prompted to
                         enter a username.
-         --configure, -c
+         -k, --insecure Allow connections to SSL sites without cert verification
+         -c, --configure
                         If set, will prompt user for configuration
                         parameters and then exit.
          --profile PROFILE, -p PROFILE
@@ -128,7 +129,7 @@ class GimmeAWSCreds(object):
         if conf_dict['gimme_creds_server'] in [None, '']:
             print('No gimme-creds-server URL in configuration.  Try running --config again.')
 
-        okta = OktaClient(okta_org_url, False)
+        okta = OktaClient(okta_org_url, config.verify_ssl_certs)
         if config.username is not None:
             okta.set_username(config.username)
 

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -53,7 +53,7 @@ class GimmeAWSCreds(object):
                         be used instead of the default profile.
 
         Config Options:
-           idp_entry_url = Okta URL
+           okta_org_url = Okta URL
            write_aws_creds = Option to write creds to ~/.aws/credentials
            cred_profile = Use DEFAULT or Role as the profile in ~/.aws/credentials
            aws_appname = (optional) Okta AWS App Name
@@ -68,7 +68,7 @@ class GimmeAWSCreds(object):
         self.role_arn = None
 
     @staticmethod
-    def _get_okta_api_key(username, password, idp_entry_url, cerberus_url=None):
+    def _get_okta_api_key(username, password, okta_org_url, cerberus_url=None):
         """returns the Okta API key from
         env var OKTA_API_KEY or from cerberus.
         This assumes your SDB is named Okta and
@@ -83,7 +83,7 @@ class GimmeAWSCreds(object):
             try:
                 cerberus = CerberusClient(cerberus_url, username, password)
                 path = cerberus.get_sdb_path('Okta')
-                key = urlparse(idp_entry_url).netloc
+                key = urlparse(okta_org_url).netloc
                 secret = cerberus.get_secret(path + '/api_key', key)
             except MissingSchema:
                 print('No Cerberus URL in configuration or OKTA_API_KEY environmental variable; unable to continue.')
@@ -143,20 +143,20 @@ class GimmeAWSCreds(object):
         conf_dict = config.get_config_dict()
         config.get_user_creds()
 
-        if conf_dict['idp_entry_url'] in [None, '']:
-            print('No IDP entry URL in configuration.  Try running --config again.')
+        if conf_dict['okta_org_url'] in [None, '']:
+            print('No Okta organization URL in configuration.  Try running --config again.')
 
-        idp_entry_url = conf_dict['idp_entry_url'] + '/api/v1'
+        okta_org_url = conf_dict['okta_org_url'] + '/api/v1'
 
         # create otka client
         api_key = self._get_okta_api_key(
             config.username,
             config.password,
-            idp_entry_url,
+            okta_org_url,
             cerberus_url=conf_dict['cerberus_url']
         )
 
-        okta = OktaClient(idp_entry_url, api_key, config.username, config.password)
+        okta = OktaClient(okta_org_url, api_key, config.username, config.password)
 
         # check to see if appname and rolename are set
         # in the config, if not give user a selection to pick from

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -145,7 +145,8 @@ class GimmeAWSCreds(object):
         if not conf_dict['aws_rolename']:
             aws_role = okta.choose_role(aws_app)
         else:
-            aws_role = okta.get_role_by_name(aws_app, conf_dict['aws_rolename'])
+            aws_role = okta.get_role_by_name(
+                aws_app, conf_dict['aws_rolename'])
 
         # Get the the identityProviderArn from the aws app
         self.idp_arn = aws_app['identityProviderArn']
@@ -178,10 +179,12 @@ class GimmeAWSCreds(object):
         else:
             # Print out temporary AWS credentials.
             print("export AWS_ACCESS_KEY_ID=" + aws_creds['AccessKeyId'])
-            print("export AWS_SECRET_ACCESS_KEY=" + aws_creds['SecretAccessKey'])
+            print("export AWS_SECRET_ACCESS_KEY=" +
+                  aws_creds['SecretAccessKey'])
             print("export AWS_SESSION_TOKEN=" + aws_creds['SessionToken'])
 
         config.clean_up()
+
 
 if __name__ == '__main__':
     GimmeAWSCreds().run()

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -134,32 +134,25 @@ class GimmeAWSCreds(object):
 
         okta.login(conf_dict['embed_link'], conf_dict['gimme_creds_server'])
 
-        print(okta.aws_access)
-
-        exit()
-
         # check to see if appname and rolename are set
         # in the config, if not give user a selection to pick from
         if not conf_dict['aws_appname']:
-            aws_appname = okta.get_app()
+            aws_app = okta.choose_app()
         else:
-            aws_appname = conf_dict['aws_appname']
+            aws_app = okta.get_app_by_name(conf_dict['aws_appname'])
 
         if not conf_dict['aws_rolename']:
-            aws_rolename = okta.get_role(aws_appname)
+            aws_role = okta.choose_role(aws_app)
         else:
-            aws_rolename = conf_dict['aws_rolename']
-
-        # get the applinks available to the user
-        app_url = okta.get_app_url(aws_appname)
+            aws_role = okta.get_role_by_name(aws_app, conf_dict['aws_rolename'])
 
         # Get the the identityProviderArn from the aws app
-        self.idp_arn = okta.get_idp_arn(app_url['appInstanceId'])
+        self.idp_arn = aws_app['identityProviderArn']
 
         # Get the role ARNs
-        self.role_arn = okta.get_role_arn(app_url['linkUrl'], aws_rolename)
+        self.role_arn = aws_role['arn']
 
-        assertion = okta.get_saml_assertion(app_url['linkUrl'])
+        assertion = okta.get_saml_assertion(aws_app['links']['appLink'])
         aws_creds = self._get_sts_creds(assertion)
 
         # check if write_aws_creds is true if so

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -106,6 +106,18 @@ class GimmeAWSCreds(object):
 
         return response['Credentials']
 
+    def _get_aws_account_info(self, okta_connection, gimme_creds_server_url):
+        """ Retrieve the user's AWS accounts from the gimme_creds_server"""
+        api_url = gimme_creds_server_url + '/api/v1/accounts'
+        response = okta_connection.get(api_url)
+
+        # Throw an error if we didn't get any accounts back
+        if response.json() == []:
+            print("No AWS accounts found.")
+            exit()
+
+        return response.json()
+
     def run(self):
         """ Pulling it all together to make the CLI """
         config = Config()
@@ -121,7 +133,7 @@ class GimmeAWSCreds(object):
         if conf_dict['okta_org_url'] in [None, '']:
             print('No Okta organization URL in configuration.  Try running --config again.')
 
-        okta_org_url = conf_dict['okta_org_url'] + '/api/v1'
+        okta_org_url = conf_dict['okta_org_url']
 
         if conf_dict['embed_link'] in [None, '']:
             print('No IdP-initiated login URL (embed link) in configuration.  Try running --config again.')
@@ -133,9 +145,20 @@ class GimmeAWSCreds(object):
         if config.username is not None:
             okta.set_username(config.username)
 
+        # tokens = okta.auth_oauth('tocqhTv1QcotXrNqnTXg',
+        #     authorization_server='aus9cz9q21TeYIzid0h7',
+        #     access_token=True,
+        #     id_token=False,
+        #     scopes=['openid']
+        # )
+        #
+        # print(tokens)
+        #
+        # sys.exit()
+
         okta.stepup_auth_saml(conf_dict['embed_link'])
         print("Authentication Success! Getting AWS Accounts...")
-        aws_results = okta.get_aws_account_info(conf_dict['gimme_creds_server'])
+        aws_results = self._get_aws_account_info(okta, conf_dict['gimme_creds_server'])
 
         # check to see if appname and rolename are set
         # in the config, if not give user a selection to pick from

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -133,14 +133,16 @@ class GimmeAWSCreds(object):
         if config.username is not None:
             okta.set_username(config.username)
 
-        okta.login(conf_dict['embed_link'], conf_dict['gimme_creds_server'])
+        okta.login(conf_dict['embed_link'])
+        aws_results = okta.get_aws_account_info(conf_dict['gimme_creds_server'])
 
         # check to see if appname and rolename are set
         # in the config, if not give user a selection to pick from
         if not conf_dict['aws_appname']:
-            aws_app = okta.choose_app()
+            aws_app = okta.choose_app(aws_results)
         else:
-            aws_app = okta.get_app_by_name(conf_dict['aws_appname'])
+            aws_app = okta.get_app_by_name(
+                aws_results, conf_dict['aws_appname'])
 
         if not conf_dict['aws_rolename']:
             aws_role = okta.choose_role(aws_app)

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -20,7 +20,6 @@ from urllib.parse import urlparse
 
 import boto3
 # local imports
-from cerberus.client import CerberusClient
 from requests.exceptions import MissingSchema
 
 from gimme_aws_creds.config import Config
@@ -54,11 +53,11 @@ class GimmeAWSCreds(object):
 
         Config Options:
            okta_org_url = Okta URL
+           embed_link = IdP-initiated login URL for the gimme-creds-server
            write_aws_creds = Option to write creds to ~/.aws/credentials
            cred_profile = Use DEFAULT or Role as the profile in ~/.aws/credentials
            aws_appname = (optional) Okta AWS App Name
            aws_rolename =  (optional) Okta Role Name
-           cerberus_url = (optional) Cerberus URL, for retrieving Okta API key
     """
     FILE_ROOT = expanduser("~")
     AWS_CONFIG = FILE_ROOT + '/.aws/credentials'
@@ -66,30 +65,6 @@ class GimmeAWSCreds(object):
     def __init__(self):
         self.idp_arn = None
         self.role_arn = None
-
-    @staticmethod
-    def _get_okta_api_key(username, password, okta_org_url, cerberus_url=None):
-        """returns the Okta API key from
-        env var OKTA_API_KEY or from cerberus.
-        This assumes your SDB is named Okta and
-        your Vault path ends is api_key"""
-        if os.environ.get("OKTA_API_KEY") is not None:
-            secret = os.environ.get("OKTA_API_KEY")
-        else:
-            if cerberus_url == ('' or None):
-                print('No Cerberus URL in configuration or OKTA_API_KEY environmental variable; unable to continue.')
-                sys.exit(1)
-
-            try:
-                cerberus = CerberusClient(cerberus_url, username, password)
-                path = cerberus.get_sdb_path('Okta')
-                key = urlparse(okta_org_url).netloc
-                secret = cerberus.get_secret(path + '/api_key', key)
-            except MissingSchema:
-                print('No Cerberus URL in configuration or OKTA_API_KEY environmental variable; unable to continue.')
-                sys.exit(1)
-
-        return secret
 
     #  this is modified code from https://github.com/nimbusscale/okta_aws_login
     def _write_aws_creds(self, profile, access_key, secret_key, token):
@@ -141,7 +116,6 @@ class GimmeAWSCreds(object):
 
         # get the config dict
         conf_dict = config.get_config_dict()
-        config.get_user_creds()
 
         if conf_dict['okta_org_url'] in [None, '']:
             print('No Okta organization URL in configuration.  Try running --config again.')
@@ -153,15 +127,13 @@ class GimmeAWSCreds(object):
 
         embed_link = conf_dict['embed_link']
 
-        # create otka client
-        api_key = self._get_okta_api_key(
-            config.username,
-            config.password,
-            okta_org_url,
-            cerberus_url=conf_dict['cerberus_url']
-        )
+        okta = OktaClient(okta_org_url, False)
+        if config.username is not None:
+            okta.set_username(config.username)
 
-        okta = OktaClient(okta_org_url, api_key, config.username, config.password)
+        okta.login(embed_link)
+
+        exit()
 
         # check to see if appname and rolename are set
         # in the config, if not give user a selection to pick from

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -148,6 +148,11 @@ class GimmeAWSCreds(object):
 
         okta_org_url = conf_dict['okta_org_url'] + '/api/v1'
 
+        if conf_dict['embed_link'] in [None, '']:
+            print('No IdP-initiated login URL (embed link) in configuration.  Try running --config again.')
+
+        embed_link = conf_dict['embed_link']
+
         # create otka client
         api_key = self._get_okta_api_key(
             config.username,

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -14,14 +14,16 @@ See the License for the specific language governing permissions and* limitations
 import configparser
 import os
 import sys
+import re
+import json
 from os.path import expanduser
 # extras
-from urllib.parse import urlparse
-
 import boto3
-# local imports
+from urllib.parse import urlparse
 from requests.exceptions import MissingSchema
-
+from okta.framework.ApiClient import ApiClient
+from okta.framework.OktaError import OktaError
+# local imports
 from gimme_aws_creds.config import Config
 from gimme_aws_creds.okta import OktaClient
 
@@ -108,7 +110,7 @@ class GimmeAWSCreds(object):
 
         return response['Credentials']
 
-    def _get_aws_account_info(self, okta_connection, gimme_creds_server_url):
+    def _call_gimmie_creds_server(self, okta_connection, gimme_creds_server_url):
         """ Retrieve the user's AWS accounts from the gimme_creds_server"""
         response = okta_connection.get(gimme_creds_server_url)
 
@@ -118,6 +120,77 @@ class GimmeAWSCreds(object):
             exit()
 
         return response.json()
+
+    def _get_aws_account_info(self, okta_org_url, okta_api_key, username):
+        """ Call the Okta User and App APIs and process the results to return
+        just the information we need for gimme_aws_creds"""
+        # We need access to the entire JSON response from the Okta APIs, so we need to
+        # use the low-level ApiClient instead of UsersClient and AppInstanceClient
+        usersClient = ApiClient(okta_org_url, okta_api_key,
+                                pathname='/api/v1/users')
+        appClient = ApiClient(okta_org_url, okta_api_key,
+                              pathname='/api/v1/apps')
+
+        # Get User information
+        try:
+            result = usersClient.get_path('/{0}'.format(username))
+            user = result.json()
+        except OktaError as e:
+            if e.error_code == 'E0000007':
+                print("Error: " + username + " was not found!")
+                exit(1)
+            else:
+                print("Error: " + e.error_summary)
+                exit(1)
+
+        # Get a list of apps for this user and include extended info about the user
+        params = {
+            'limit': 200,
+            'filter': 'user.id+eq+%22' + user['id'] + '%22&expand=user%2F' + user['id']
+        }
+
+        try:
+            result = appClient.get_path('/', params=params)
+        except OktaError as e:
+            if e.error_code == 'E0000007':
+                print("Error: No applications found for " + username)
+                exit(1)
+            else:
+                print("Error: " + e.error_summary)
+                exit(1)
+
+
+        appList = []
+
+        # Loop through the list of apps and filter it down to just the info we need
+        for app in result.json():
+            # All AWS connections have the same app name
+            if (app['name'] == 'amazon_aws'):
+                newAppEntry = {}
+                newAppEntry['id'] = app['id']
+                newAppEntry['name'] = app['label']
+                newAppEntry['identityProviderArn'] = app['settings']['app']['identityProviderArn']
+                newAppEntry['roles'] = []
+                # Build a list of the roles this user has access to
+                for role in app['_embedded']['user']['profile']['samlRoles']:
+                    roleInfo = {}
+                    roleInfo['name'] = role
+                    # We can figure out the role ARN based on the ARN for the IdP
+                    roleInfo['arn'] = re.sub(':saml-provider.*',
+                                             ':role/' + role,
+                                             app['settings']['app']['identityProviderArn'])
+                    newAppEntry['roles'].append(roleInfo)
+                newAppEntry['links'] = {}
+                newAppEntry['links']['appLink'] = app['_links']['appLinks'][0]['href']
+                newAppEntry['links']['appLogo'] = app['_links']['logo'][0]['href']
+                appList.append(newAppEntry)
+
+        # Throw an error if we didn't get any accounts back
+        if appList == []:
+            print("No AWS accounts found.")
+            exit()
+
+        return appList
 
     def _choose_app(self, aws_info):
         """ gets a list of available apps and
@@ -184,32 +257,47 @@ class GimmeAWSCreds(object):
 
         if conf_dict['okta_org_url'] in [None, '']:
             print('No Okta organization URL in configuration.  Try running --config again.')
+            sys.exit(1)
 
-        okta_org_url = conf_dict['okta_org_url']
-
-        if conf_dict['client_id'] in [None, '']:
-            print('No OAuth Client ID in configuration.  Try running --config again.')
-
-        if conf_dict['gimme_creds_server'] in [None, '']:
-            print('No gimme-creds-server URL in configuration.  Try running --config again.')
-
-        okta = OktaClient(okta_org_url, config.verify_ssl_certs)
+        okta = OktaClient(conf_dict['okta_org_url'], config.verify_ssl_certs)
         if config.username is not None:
             okta.set_username(config.username)
 
-        # Authenticate with Okta
-        tokens = okta.auth_oauth(conf_dict['client_id'],
-            authorization_server=conf_dict['okta_auth_server'],
-            access_token=True,
-            id_token=False,
-            scopes=['openid']
-        )
+        # Call the Okta APIs and proces data locally
+        if conf_dict['gimme_creds_server'] == 'internal':
+            # Okta API key is required when calling Okta APIs internally
+            if config.api_key is None:
+                print('OKTA_API_KEY environment variable not found!')
+                sys.exit(1)
+            # Authenticate with Okta
+            auth_result = okta.auth_session()
 
-        # Add Access Tokens to Okta-protected requests
-        okta.use_oauth_access_token(True)
+            print("Authentication Success! Getting AWS Accounts...")
+            aws_results = self._get_aws_account_info(conf_dict['okta_org_url'], config.api_key, auth_result['username'])
 
-        print("Authentication Success! Getting AWS Accounts...")
-        aws_results = self._get_aws_account_info(okta, conf_dict['gimme_creds_server'])
+            print(aws_results)
+
+        # Use the gimme_creds_lambda service
+        else:
+            if conf_dict['gimme_creds_server'] in [None, '']:
+                print('No Gimme-Creds server URL in configuration.  Try running --config again.')
+            if conf_dict['client_id'] in [None, '']:
+                print('No OAuth Client ID in configuration.  Try running --config again.')
+            if conf_dict['okta_auth_server'] in [None, '']:
+                print('No OAuth Authorization server in configuration.  Try running --config again.')
+            # Authenticate with Okta and get an OAuth access token
+            tokens = okta.auth_oauth(conf_dict['client_id'],
+                authorization_server=conf_dict['okta_auth_server'],
+                access_token=True,
+                id_token=False,
+                scopes=['openid']
+            )
+
+            # Add Access Tokens to Okta-protected requests
+            okta.use_oauth_access_token(True)
+
+            print("Authentication Success! Calling Gimme-Creds Server...")
+            aws_results = self._call_gimmie_creds_server(okta, conf_dict['gimme_creds_server'])
 
         # check to see if appname and rolename are set
         # in the config, if not give user a selection to pick from

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -134,6 +134,7 @@ class GimmeAWSCreds(object):
             okta.set_username(config.username)
 
         okta.login(conf_dict['embed_link'])
+        print("Authentication Success! Getting AWS Accounts...")
         aws_results = okta.get_aws_account_info(conf_dict['gimme_creds_server'])
 
         # check to see if appname and rolename are set

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -118,6 +118,57 @@ class GimmeAWSCreds(object):
 
         return response.json()
 
+    def _choose_app(self, aws_info):
+        """ gets a list of available apps and
+        ask the user to select the app they want
+        to assume a roles for and returns the selection
+        """
+
+        print("Pick an app:")
+        # print out the apps and let the user select
+        for i, app in enumerate(aws_info):
+            print('[', i, ']', app["name"])
+
+        selection = input("Selection: ")
+
+        # make sure the choice is valid
+        if int(selection) > len(aws_info):
+            print("You made an invalid selection")
+            sys.exit(1)
+
+        return aws_info[int(selection)]
+
+    def _get_app_by_name(self, aws_info, appname):
+        """ returns the app with the matching name"""
+        for i, app in enumerate(aws_info):
+            if app["name"] == appname:
+                return app
+
+    def _get_role_by_name(self, app_info, rolename):
+        """ returns the role with the matching name"""
+        for i, role in enumerate(app_info['roles']):
+            if role["name"] == rolename:
+                return role
+
+    def _choose_role(self, app_info):
+        """ gets a list of available roles and
+        asks the user to select the role they want to assume
+        """
+
+        print("Pick a role:")
+        # print out the roles and let the user select
+        for i, role in enumerate(app_info['roles']):
+            print('[', i, ']', role["name"])
+
+        selection = input("Selection: ")
+
+        # make sure the choice is valid
+        if int(selection) > len(app_info['roles']):
+            print("You made an invalid selection")
+            sys.exit(1)
+
+        return app_info['roles'][int(selection)]
+
     def run(self):
         """ Pulling it all together to make the CLI """
         config = Config()
@@ -163,15 +214,15 @@ class GimmeAWSCreds(object):
         # check to see if appname and rolename are set
         # in the config, if not give user a selection to pick from
         if not conf_dict['aws_appname']:
-            aws_app = okta.choose_app(aws_results)
+            aws_app = self._choose_app(aws_results)
         else:
-            aws_app = okta.get_app_by_name(
+            aws_app = self._get_app_by_name(
                 aws_results, conf_dict['aws_appname'])
 
         if not conf_dict['aws_rolename']:
-            aws_role = okta.choose_role(aws_app)
+            aws_role = self._choose_role(aws_app)
         else:
-            aws_role = okta.get_role_by_name(
+            aws_role = self._get_role_by_name(
                 aws_app, conf_dict['aws_rolename'])
 
         # Get the the identityProviderArn from the aws app

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -125,13 +125,16 @@ class GimmeAWSCreds(object):
         if conf_dict['embed_link'] in [None, '']:
             print('No IdP-initiated login URL (embed link) in configuration.  Try running --config again.')
 
-        embed_link = conf_dict['embed_link']
+        if conf_dict['gimme_creds_server'] in [None, '']:
+            print('No gimme-creds-server URL in configuration.  Try running --config again.')
 
         okta = OktaClient(okta_org_url, False)
         if config.username is not None:
             okta.set_username(config.username)
 
-        okta.login(embed_link)
+        okta.login(conf_dict['embed_link'], conf_dict['gimme_creds_server'])
+
+        print(okta.aws_access)
 
         exit()
 

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -133,7 +133,7 @@ class GimmeAWSCreds(object):
         if config.username is not None:
             okta.set_username(config.username)
 
-        okta.login(conf_dict['embed_link'])
+        okta.stepup_auth_saml(conf_dict['embed_link'])
         print("Authentication Success! Getting AWS Accounts...")
         aws_results = okta.get_aws_account_info(conf_dict['gimme_creds_server'])
 

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -153,8 +153,8 @@ class GimmeAWSCreds(object):
         # Get the role ARNs
         self.role_arn = aws_role['arn']
 
-        assertion = okta.get_saml_assertion(aws_app['links']['appLink'])
-        aws_creds = self._get_sts_creds(assertion)
+        saml_data = okta.get_saml_response(aws_app['links']['appLink'])
+        aws_creds = self._get_sts_creds(saml_data['SAMLResponse'])
 
         # check if write_aws_creds is true if so
         # get the profile name and write out the file

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -145,12 +145,21 @@ class GimmeAWSCreds(object):
 
         # Get a list of apps for this user and include extended info about the user
         params = {
-            'limit': 200,
+            'limit': 50,
             'filter': 'user.id+eq+%22' + user['id'] + '%22&expand=user%2F' + user['id']
         }
 
         try:
+            # Get first page of results
             result = appClient.get_path('/', params=params)
+            final_result = result.json()
+
+            # Loop through other pages
+            while 'next' in result.links:
+                print('.', end='', flush=True)
+                result = appClient.get(result.links['next']['url'])
+                final_result = final_result + result.json()
+            print("done\n")
         except OktaError as e:
             if e.error_code == 'E0000007':
                 print("Error: No applications found for " + username)
@@ -159,11 +168,9 @@ class GimmeAWSCreds(object):
                 print("Error: " + e.error_summary)
                 exit(1)
 
-
-        appList = []
-
         # Loop through the list of apps and filter it down to just the info we need
-        for app in result.json():
+        appList = []
+        for app in final_result:
             # All AWS connections have the same app name
             if (app['name'] == 'amazon_aws'):
                 newAppEntry = {}
@@ -272,10 +279,8 @@ class GimmeAWSCreds(object):
             # Authenticate with Okta
             auth_result = okta.auth_session()
 
-            print("Authentication Success! Getting AWS Accounts...")
+            print("Authentication Success! Getting AWS Accounts", end='', flush=True)
             aws_results = self._get_aws_account_info(conf_dict['okta_org_url'], config.api_key, auth_result['username'])
-
-            print(aws_results)
 
         # Use the gimme_creds_lambda service
         else:

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -109,7 +109,6 @@ class Config(object):
                 cred_profile = Use DEFAULT or Role as the profile in ~/.aws/credentials
                 aws_appname = (optional) Okta AWS App Name
                 aws_rolename =  (optional) Okta Role Name
-                cerberus_url = (optional) Cerberus URL, for retrieving Okta API key
         """
         config = configparser.ConfigParser()
         if self.configure:
@@ -119,7 +118,6 @@ class Config(object):
             'idp_entry_url': '',
             'aws_appname': '',
             'aws_rolename': '',
-            'cerberus_url': '',
             'write_aws_creds': '',
             'cred_profile': 'role'
         }
@@ -141,7 +139,6 @@ class Config(object):
             'write_aws_creds': self._get_write_aws_creds(defaults['write_aws_creds']),
             'aws_appname': self._get_aws_appname(defaults['aws_appname']),
             'aws_rolename': self._get_aws_rolename(defaults['aws_rolename']),
-            'cerberus_url': self._get_cerberus_url(defaults['cerberus_url'])
         }
 
         # If write_aws_creds is True get the profile name
@@ -222,13 +219,6 @@ class Config(object):
               "\nThis is optional, you can select the role when you run the CLI.")
         aws_rolename = self._get_user_input("AWS Role Name", default_entry)
         return aws_rolename
-
-    def _get_cerberus_url(self, default_entry):
-        """ Get and validate cerberus url - this is optional"""
-        print("If you are using Cerberus to store your Okta API Key, this is optional.\n"
-              "Enter your Cerberus URL.")
-        cerberus_url = self._get_user_input("Cerberus URL", default_entry)
-        return cerberus_url
 
     def _get_conf_profile_name(self, default_entry):
         """Get and validate configuration profile name. [Optional]"""

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -232,9 +232,10 @@ class Config(object):
 
     def _get_conf_profile_name(self, default_entry):
         """Get and validate configuration profile name. [Optional]"""
-        print("If you'd like to assign this configuration to a specific profile instead of to the default profile, "
-              "specify the name of the profile.  This is optional.")
-        conf_profile = self._get_user_input("Configuration Profile Name", default_entry)
+        print("If you'd like to assign the Okta configuration to a specific profile\n"
+              "instead of to the default profile, specify the name of the profile.\n"
+              "This is optional.")
+        conf_profile = self._get_user_input("Okta Configuration Profile Name", default_entry)
         return conf_profile
 
     @staticmethod

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -56,9 +56,18 @@ class Config(object):
             '--profile', '-p',
             help='If set, the specified configuration profile will be used instead of the default.'
         )
+        parser.add_argument(
+            '--insecure', '-k',
+            action='store_true',
+            help='Allow connections to SSL sites without cert verification.'
+        )
         args = parser.parse_args()
 
         self.configure = args.configure
+        if args.insecure is True:
+            self.verify_ssl_certs = False
+        else:
+            self.verify_ssl_certs = True
         if args.username is not None:
             self.username = args.username
         self.conf_profile = args.profile or 'DEFAULT'

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -104,7 +104,7 @@ class Config(object):
            Prompts user for config details for the okta_aws_login tool.
            Either updates existing config file or creates new one.
            Config Options:
-                idp_entry_url = Okta URL
+                okta_org_url = Okta URL
                 write_aws_creds = Option to write creds to ~/.aws/credentials
                 cred_profile = Use DEFAULT or Role as the profile in ~/.aws/credentials
                 aws_appname = (optional) Okta AWS App Name
@@ -115,7 +115,7 @@ class Config(object):
             self.conf_profile = self._get_conf_profile_name(self.conf_profile)
 
         defaults = {
-            'idp_entry_url': '',
+            'okta_org_url': '',
             'aws_appname': '',
             'aws_rolename': '',
             'write_aws_creds': '',
@@ -135,7 +135,7 @@ class Config(object):
 
         # Prompt user for config details and store in config_dict
         config_dict = {
-            'idp_entry_url': self._get_idp_entry(defaults['idp_entry_url']),
+            'okta_org_url': self._get_idp_entry(defaults['okta_org_url']),
             'write_aws_creds': self._get_write_aws_creds(defaults['write_aws_creds']),
             'aws_appname': self._get_aws_appname(defaults['aws_appname']),
             'aws_rolename': self._get_aws_rolename(defaults['aws_rolename']),
@@ -155,22 +155,22 @@ class Config(object):
             config.write(configfile)
 
     def _get_idp_entry(self, default_entry):
-        """ Get and validate idp_entry_url """
+        """ Get and validate okta_org_url """
         print("Enter the IDP Entry URL. This is https://something.okta[preview].com")
-        idp_entry_url_valid = False
-        idp_entry_url = default_entry
+        okta_org_url_valid = False
+        okta_org_url = default_entry
 
-        while idp_entry_url_valid is False:
-            idp_entry_url = self._get_user_input("IDP Entry URL", default_entry)
-            # Validate that idp_entry_url is a well formed okta URL
-            url_parse_results = urlparse(idp_entry_url)
+        while okta_org_url_valid is False:
+            okta_org_url = self._get_user_input("Okta URL for your organization: ", default_entry)
+            # Validate that okta_org_url is a well formed okta URL
+            url_parse_results = urlparse(okta_org_url)
 
-            if url_parse_results.scheme == "https" and "okta.com" or "oktapreview.com" in idp_entry_url:
-                idp_entry_url_valid = True
+            if url_parse_results.scheme == "https" and "okta.com" or "oktapreview.com" in okta_org_url:
+                okta_org_url_valid = True
             else:
-                print("IDP Entry URL must be HTTPS URL for okta.com or oktapreview.com domain")
+                print("Okta organization URL must be HTTPS URL for okta.com or oktapreview.com domain")
 
-        return idp_entry_url
+        return okta_org_url
 
     def _get_write_aws_creds(self, default_entry):
         """ Option to write to the ~/.aws/credentials or to stdour"""

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and* limitations
 """
 import argparse
 import configparser
-import getpass
 import os
 import sys
 from os.path import expanduser
@@ -31,9 +30,11 @@ class Config(object):
 
     def __init__(self):
         self.configure = False
-        self.password = None
         self.username = None
         self.conf_profile = 'DEFAULT'
+
+        if os.environ.get("OKTA_USERNAME") is not None:
+            self.username = os.environ.get("OKTA_USERNAME")
 
     def get_args(self):
         """Get the CLI args"""
@@ -58,8 +59,11 @@ class Config(object):
         args = parser.parse_args()
 
         self.configure = args.configure
-        self.username = args.username
+        if args.username is not None:
+            self.username = args.username
         self.conf_profile = args.profile or 'DEFAULT'
+
+
 
     def get_config_dict(self):
         """returns the conf dict from the okta config file"""
@@ -77,27 +81,6 @@ class Config(object):
         else:
             print('Configuration file not found! Use the --configure flag to generate file.')
             sys.exit(1)
-
-    def get_user_creds(self):
-        """Get's creds for Okta login from the user."""
-        # Check to see if the username arg has been set, if so use that
-        if self.username is not None:
-            username = self.username
-        # Next check to see if the OKTA_USERNAME env var is set
-        elif os.environ.get("OKTA_USERNAME") is not None:
-            username = os.environ.get("OKTA_USERNAME")
-        # Otherwise just ask the user
-        else:
-            username = input("Email address: ")
-        # Set prompt to include the user name, since username could be set
-        # via OKTA_USERNAME env and user might not remember.
-        passwd_prompt = "Password for {}: ".format(username)
-        password = getpass.getpass(prompt=passwd_prompt)
-        if len(password) == 0:
-            print("Password must be provided.")
-            sys.exit(1)
-        self.username = username
-        self.password = password
 
     def update_config_file(self):
         """
@@ -271,4 +254,3 @@ class Config(object):
     def clean_up(self):
         """ clean up secret stuff"""
         del self.username
-        del self.password

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -63,8 +63,6 @@ class Config(object):
             self.username = args.username
         self.conf_profile = args.profile or 'DEFAULT'
 
-
-
     def get_config_dict(self):
         """returns the conf dict from the okta config file"""
         # Check to see if config file exists, if not complain and exit
@@ -89,6 +87,7 @@ class Config(object):
            Config Options:
                 okta_org_url = Okta URL
                 embed_link = IdP-initiated login URL for the gimme-creds-server
+                gimme_creds_server = URL of the gimme_creds_server
                 write_aws_creds = Option to write creds to ~/.aws/credentials
                 cred_profile = Use DEFAULT or Role as the profile in ~/.aws/credentials
                 aws_appname = (optional) Okta AWS App Name
@@ -101,6 +100,7 @@ class Config(object):
         defaults = {
             'okta_org_url': '',
             'embed_link': '',
+            'gimme_creds_server': '',
             'aws_appname': '',
             'aws_rolename': '',
             'write_aws_creds': '',
@@ -121,6 +121,7 @@ class Config(object):
         # Prompt user for config details and store in config_dict
         config_dict = {
             'okta_org_url': self._get_org_url_entry(defaults['okta_org_url']),
+            'gimme_creds_server': self._get_gimme_creds_server_entry(defaults['gimme_creds_server']),
             'embed_link': self._get_embed_link_entry(defaults['embed_link']),
             'write_aws_creds': self._get_write_aws_creds(defaults['write_aws_creds']),
             'aws_appname': self._get_aws_appname(defaults['aws_appname']),
@@ -177,6 +178,24 @@ class Config(object):
                 print("Embed link URL must be a URL in your organization's Okta domain (%s)" % (self._okta_org_url))
 
         return embed_link
+
+    def _get_gimme_creds_server_entry(self, default_entry):
+        """ Get gimme_creds_server """
+        print("Enter the URL for the gimme-creds-server.")
+        gimme_creds_server_valid = False
+        gimme_creds_server = default_entry
+
+        while gimme_creds_server_valid is False:
+            gimme_creds_server = self._get_user_input("URL for gimme-creds-server", default_entry)
+            # Validate that embed_link is a well formed URL
+            url_parse_results = urlparse(gimme_creds_server)
+
+            if url_parse_results.scheme == "https":
+                gimme_creds_server_valid = True
+            else:
+                print("The gimme-creds-server must be a HTTPS URL")
+
+        return gimme_creds_server
 
     def _get_write_aws_creds(self, default_entry):
         """ Option to write to the ~/.aws/credentials or to stdour"""

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -31,10 +31,15 @@ class Config(object):
     def __init__(self):
         self.configure = False
         self.username = None
+        self.api_key = None
         self.conf_profile = 'DEFAULT'
 
         if os.environ.get("OKTA_USERNAME") is not None:
             self.username = os.environ.get("OKTA_USERNAME")
+
+        if os.environ.get("OKTA_API_KEY") is not None:
+            self.api_key = os.environ.get("OKTA_API_KEY")
+
 
     def get_args(self):
         """Get the CLI args"""
@@ -96,7 +101,7 @@ class Config(object):
            Either updates existing config file or creates new one.
            Config Options:
                 okta_org_url = Okta URL
-                gimme_creds_server = URL of the gimme-creds-server
+                gimme_creds_server = URL of the gimme-creds-server or 'internal' for local processing
                 client_id = OAuth Client id for the gimme-creds-server
                 okta_auth_server = Server ID for the OAuth authorization server used by gimme-creds-server
                 write_aws_creds = Option to write creds to ~/.aws/credentials
@@ -112,7 +117,7 @@ class Config(object):
             'okta_org_url': '',
             'okta_auth_server': '',
             'client_id': '',
-            'gimme_creds_server': '',
+            'gimme_creds_server': 'internal',
             'aws_appname': '',
             'aws_rolename': '',
             'write_aws_creds': '',
@@ -131,15 +136,17 @@ class Config(object):
                     defaults[default] = profile.get(default, defaults[default])
 
         # Prompt user for config details and store in config_dict
-        config_dict = {
-            'okta_org_url': self._get_org_url_entry(defaults['okta_org_url']),
-            'okta_auth_server': self._get_auth_server_entry(defaults['okta_auth_server']),
-            'client_id': self._get_client_id_entry(defaults['client_id']),
-            'gimme_creds_server': self._get_gimme_creds_server_entry(defaults['gimme_creds_server']),
-            'write_aws_creds': self._get_write_aws_creds(defaults['write_aws_creds']),
-            'aws_appname': self._get_aws_appname(defaults['aws_appname']),
-            'aws_rolename': self._get_aws_rolename(defaults['aws_rolename']),
-        }
+        config_dict = defaults
+        config_dict['okta_org_url'] = self._get_org_url_entry(defaults['okta_org_url'])
+        config_dict['gimme_creds_server'] = self._get_gimme_creds_server_entry(defaults['gimme_creds_server'])
+
+        if config_dict['gimme_creds_server'] != 'internal':
+            config_dict['client_id'] = self._get_client_id_entry(defaults['client_id'])
+            config_dict['okta_auth_server'] = self._get_auth_server_entry(defaults['okta_auth_server'])
+
+        config_dict['write_aws_creds'] = self._get_write_aws_creds(defaults['write_aws_creds'])
+        config_dict['aws_appname'] = self._get_aws_appname(defaults['aws_appname'])
+        config_dict['aws_rolename'] = self._get_aws_rolename(defaults['aws_rolename'])
 
         # If write_aws_creds is True get the profile name
         if config_dict['write_aws_creds'] is True:
@@ -198,19 +205,22 @@ class Config(object):
 
     def _get_gimme_creds_server_entry(self, default_entry):
         """ Get gimme_creds_server """
-        print("Enter the URL for the gimme-creds-server.")
+        print("Enter the URL for the gimme-creds-server or 'internal' for handling Okta APIs locally.")
         gimme_creds_server_valid = False
         gimme_creds_server = default_entry
 
         while gimme_creds_server_valid is False:
             gimme_creds_server = self._get_user_input(
                 "URL for gimme-creds-server", default_entry)
-            url_parse_results = urlparse(gimme_creds_server)
-
-            if url_parse_results.scheme == "https":
+            if gimme_creds_server == "internal":
                 gimme_creds_server_valid = True
             else:
-                print("The gimme-creds-server must be a HTTPS URL")
+                url_parse_results = urlparse(gimme_creds_server)
+
+                if url_parse_results.scheme == "https":
+                    gimme_creds_server_valid = True
+                else:
+                    print("The gimme-creds-server must be a HTTPS URL")
 
         return gimme_creds_server
 
@@ -293,3 +303,4 @@ class Config(object):
     def clean_up(self):
         """ clean up secret stuff"""
         del self.username
+        del self.api_key

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -205,7 +205,6 @@ class Config(object):
         while gimme_creds_server_valid is False:
             gimme_creds_server = self._get_user_input(
                 "URL for gimme-creds-server", default_entry)
-            # Validate that embed_link is a well formed URL
             url_parse_results = urlparse(gimme_creds_server)
 
             if url_parse_results.scheme == "https":

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -96,8 +96,9 @@ class Config(object):
            Either updates existing config file or creates new one.
            Config Options:
                 okta_org_url = Okta URL
-                embed_link = IdP-initiated login URL for the gimme-creds-server
-                gimme_creds_server = URL of the gimme_creds_server
+                gimme_creds_server = URL of the gimme-creds-server
+                client_id = OAuth Client id for the gimme-creds-server
+                okta_auth_server = Server ID for the OAuth authorization server used by gimme-creds-server
                 write_aws_creds = Option to write creds to ~/.aws/credentials
                 cred_profile = Use DEFAULT or Role as the profile in ~/.aws/credentials
                 aws_appname = (optional) Okta AWS App Name
@@ -109,7 +110,8 @@ class Config(object):
 
         defaults = {
             'okta_org_url': '',
-            'embed_link': '',
+            'okta_auth_server': '',
+            'client_id': '',
             'gimme_creds_server': '',
             'aws_appname': '',
             'aws_rolename': '',
@@ -131,8 +133,9 @@ class Config(object):
         # Prompt user for config details and store in config_dict
         config_dict = {
             'okta_org_url': self._get_org_url_entry(defaults['okta_org_url']),
+            'okta_auth_server': self._get_auth_server_entry(defaults['okta_auth_server']),
+            'client_id': self._get_client_id_entry(defaults['client_id']),
             'gimme_creds_server': self._get_gimme_creds_server_entry(defaults['gimme_creds_server']),
-            'embed_link': self._get_embed_link_entry(defaults['embed_link']),
             'write_aws_creds': self._get_write_aws_creds(defaults['write_aws_creds']),
             'aws_appname': self._get_aws_appname(defaults['aws_appname']),
             'aws_rolename': self._get_aws_rolename(defaults['aws_rolename']),
@@ -173,24 +176,25 @@ class Config(object):
 
         return okta_org_url
 
-    def _get_embed_link_entry(self, default_entry):
-        """ Get and validate embed_link """
-        print("Enter the IdP-initiated login URL (embed link) for gimme-creds-server. If you do not know this URL, contact your Okta admin")
-        embed_link_valid = False
-        embed_link = default_entry
+    def _get_auth_server_entry(self, default_entry):
+        """ Get and validate okta_auth_server """
+        print("Enter the OAuth authorization server for the gimme-creds-server. If you do not know this value, contact your Okta admin")
+        okta_auth_server = default_entry
 
-        while embed_link_valid is False:
-            embed_link = self._get_user_input(
-                "Login URL for gimme-creds-server", default_entry)
-            # Validate that embed_link is a well formed okta URL
-            url_parse_results = urlparse(embed_link)
+        okta_auth_server = self._get_user_input("Authorization server", default_entry)
+        self._okta_auth_server = okta_auth_server
 
-            if self._okta_org_url in embed_link and "/home/" in url_parse_results.path:
-                embed_link_valid = True
-            else:
-                print("Embed link URL must be a URL in your organization's Okta domain (%s)" % (self._okta_org_url))
+        return okta_auth_server
 
-        return embed_link
+    def _get_client_id_entry(self, default_entry):
+        """ Get and validate client_id """
+        print("Enter the OAuth client id for the gimme-creds-server. If you do not know this value, contact your Okta admin")
+        client_id = default_entry
+
+        client_id = self._get_user_input("Client ID", default_entry)
+        self._client_id = client_id
+
+        return client_id
 
     def _get_gimme_creds_server_entry(self, default_entry):
         """ Get gimme_creds_server """

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -140,7 +140,8 @@ class Config(object):
 
         # If write_aws_creds is True get the profile name
         if config_dict['write_aws_creds'] is True:
-            config_dict['cred_profile'] = self._get_cred_profile(defaults['cred_profile'])
+            config_dict['cred_profile'] = self._get_cred_profile(
+                defaults['cred_profile'])
         else:
             config_dict['cred_profile'] = defaults['cred_profile']
 
@@ -158,7 +159,8 @@ class Config(object):
         okta_org_url = default_entry
 
         while okta_org_url_valid is False:
-            okta_org_url = self._get_user_input("Okta URL for your organization", default_entry)
+            okta_org_url = self._get_user_input(
+                "Okta URL for your organization", default_entry)
             # Validate that okta_org_url is a well formed okta URL
             url_parse_results = urlparse(okta_org_url)
 
@@ -178,7 +180,8 @@ class Config(object):
         embed_link = default_entry
 
         while embed_link_valid is False:
-            embed_link = self._get_user_input("Login URL for gimme-creds-server", default_entry)
+            embed_link = self._get_user_input(
+                "Login URL for gimme-creds-server", default_entry)
             # Validate that embed_link is a well formed okta URL
             url_parse_results = urlparse(embed_link)
 
@@ -196,7 +199,8 @@ class Config(object):
         gimme_creds_server = default_entry
 
         while gimme_creds_server_valid is False:
-            gimme_creds_server = self._get_user_input("URL for gimme-creds-server", default_entry)
+            gimme_creds_server = self._get_user_input(
+                "URL for gimme-creds-server", default_entry)
             # Validate that embed_link is a well formed URL
             url_parse_results = urlparse(gimme_creds_server)
 
@@ -215,7 +219,8 @@ class Config(object):
         write_aws_creds = None
         while write_aws_creds is not True and write_aws_creds is not False:
             default_entry = 'y' if default_entry is True else 'n'
-            answer = self._get_user_input("Write AWS Credentials", default_entry)
+            answer = self._get_user_input(
+                "Write AWS Credentials", default_entry)
             answer = answer.lower()
 
             if answer == 'y':
@@ -234,7 +239,8 @@ class Config(object):
               "If set to 'default' then the temp creds will be stored in the default profile\n"
               "If set to any other value, the name of the profile will match that value.")
 
-        cred_profile = self._get_user_input("AWS Credential Profile", default_entry)
+        cred_profile = self._get_user_input(
+            "AWS Credential Profile", default_entry)
 
         if cred_profile.lower() in ['default', 'role']:
             cred_profile = cred_profile.lower()
@@ -260,7 +266,8 @@ class Config(object):
         print("If you'd like to assign the Okta configuration to a specific profile\n"
               "instead of to the default profile, specify the name of the profile.\n"
               "This is optional.")
-        conf_profile = self._get_user_input("Okta Configuration Profile Name", default_entry)
+        conf_profile = self._get_user_input(
+            "Okta Configuration Profile Name", default_entry)
         return conf_profile
 
     @staticmethod

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -65,6 +65,7 @@ class Config(object):
 
         self.configure = args.configure
         if args.insecure is True:
+            print("Warning: SSL certificate validation is disabled!")
             self.verify_ssl_certs = False
         else:
             self.verify_ssl_certs = True

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -191,7 +191,6 @@ class OktaClient(object):
         """ return the base64 SAML value object from the SAML Response"""
         response = self.req_session.get(url, verify=self._verify_ssl_certs)
 
-        form_action = saml_soup.find('form').get('action')
         saml_response = None
         relay_state = None
         form_action = None

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -39,6 +39,9 @@ class OktaClient(object):
         self._okta_org_url = okta_org_url
         self._verify_ssl_certs = verify_ssl_certs
 
+        if (verify_ssl_certs is False):
+            requests.packages.urllib3.disable_warnings()
+
         self._server_embed_link = None
         self._username = None
 

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -107,6 +107,32 @@ class OktaClient(object):
 
         return flowState['apiResponse']
 
+    def auth_session(self, **kwargs):
+        """ Authenticate the user and return the Okta Session ID and username"""
+        loginResponse = self.auth()
+
+        session_url = self._okta_org_url + '/login/sessionCookieRedirect'
+
+        if 'redirect_uri' not in kwargs:
+            redirect_uri = 'http://localhost:8080/login'
+        else:
+            redirect_uri = kwargs['redirect_uri']
+
+        params = {
+            'token': loginResponse['sessionToken'],
+            'redirectUrl': redirect_uri
+        }
+
+        response = self._http_client.get(
+            session_url,
+            params=params,
+            headers=self._get_headers(),
+            verify=self._verify_ssl_certs,
+            allow_redirects=False
+        )
+
+        return {"username": loginResponse['_embedded']['user']['profile']['login'], "session": response.cookies['sid']}
+
     def auth_oauth(self, client_id, **kwargs):
         """ Login to Okta and retrieve access token, ID token or both """
         loginResponse = self.auth()
@@ -368,12 +394,12 @@ class OktaClient(object):
         if self._use_oauth_access_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_access_token
+            kwargs['headers']['Authorization'] = "Bearer {}".format(self._oauth_access_token)
 
         if self._use_oauth_id_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_id_token
+            kwargs['headers']['Authorization'] = "Bearer {}".format(self._oauth_access_token)
         return self._http_client.get(url, **kwargs )
 
     def post(self, url, **kwargs):
@@ -381,12 +407,12 @@ class OktaClient(object):
         if self._use_oauth_access_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_access_token
+            kwargs['headers']['Authorization'] = "Bearer {}".format(self._oauth_access_token)
 
         if self._use_oauth_id_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_id_token
+            kwargs['headers']['Authorization'] = "Bearer {}".format(self._oauth_access_token)
         return self._http_client.post(url, **kwargs )
 
     def put(self, url, **kwargs):
@@ -394,12 +420,12 @@ class OktaClient(object):
         if self._use_oauth_access_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_access_token
+            kwargs['headers']['Authorization'] = "Bearer {}".format(self._oauth_access_token)
 
         if self._use_oauth_id_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_id_token
+            kwargs['headers']['Authorization'] = "Bearer {}".format(self._oauth_access_token)
         return self._http_client.put(url, **kwargs )
 
     def delete(self, url, **kwargs):
@@ -407,12 +433,12 @@ class OktaClient(object):
         if self._use_oauth_access_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_access_token
+            kwargs['headers']['Authorization'] = "Bearer {}".format(self._oauth_access_token)
 
         if self._use_oauth_id_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_id_token
+            kwargs['headers']['Authorization'] = "Bearer {}".format(self._oauth_access_token)
         return self._http_client.delete(url, **kwargs )
 
     def _choose_factor(self, factors):

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -368,12 +368,12 @@ class OktaClient(object):
         if self._use_oauth_access_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = self._oauth_access_token
+            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_access_token
 
         if self._use_oauth_id_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = self._oauth_id_token
+            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_id_token
         return self._http_client.get(url, **kwargs )
 
     def post(self, url, **kwargs):
@@ -381,12 +381,12 @@ class OktaClient(object):
         if self._use_oauth_access_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = self._oauth_access_token
+            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_access_token
 
         if self._use_oauth_id_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = self._oauth_id_token
+            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_id_token
         return self._http_client.post(url, **kwargs )
 
     def put(self, url, **kwargs):
@@ -394,12 +394,12 @@ class OktaClient(object):
         if self._use_oauth_access_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = self._oauth_access_token
+            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_access_token
 
         if self._use_oauth_id_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = self._oauth_id_token
+            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_id_token
         return self._http_client.put(url, **kwargs )
 
     def delete(self, url, **kwargs):
@@ -407,12 +407,12 @@ class OktaClient(object):
         if self._use_oauth_access_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = self._oauth_access_token
+            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_access_token
 
         if self._use_oauth_id_token is True:
             if 'headers' not in kwargs:
                 kwargs['headers'] = {}
-            kwargs['headers']['Authorization'] = self._oauth_id_token
+            kwargs['headers']['Authorization'] = "Bearer " + self._oauth_id_token
         return self._http_client.delete(url, **kwargs )
 
     def _choose_factor(self, factors):

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -42,16 +42,18 @@ class OktaClient(object):
         self._login_saml_form_action = None
         self._login_saml_relay_state = None
 
-        # self._get_aws_info()
+        self.aws_access = None
+
+        self.req_session = requests.Session()
 
     def set_username(self, username):
         self._username = username
 
-    def login(self, embed_link):
-        """ set the user credentials"""
+    def login(self, embed_link, gimme_creds_server_url):
+        """ Login to Okta and request data from the gimme-creds-server"""
         self._server_embed_link = embed_link
         self._start_login_flow()
-        self._get_aws_account_info()
+        self._get_aws_account_info(gimme_creds_server_url)
 
     def _get_headers(self):
         """sets the default headers"""
@@ -62,11 +64,11 @@ class OktaClient(object):
 
     def _start_login_flow(self):
         """ gets the starts the authentication flow with Okta"""
-        response = requests.get(self._server_embed_link , allow_redirects=False)
+        response = self.req_session.get(self._server_embed_link , allow_redirects=False)
         url_parse_results = urlparse(response.headers['Location'])
         stateToken =  parse_qs(url_parse_results.query)['stateToken'][0]
 
-        response = requests.post(
+        response = self.req_session.post(
             self._okta_org_url + '/authn',
             json={'stateToken': stateToken},
             headers=self._get_headers()
@@ -76,7 +78,7 @@ class OktaClient(object):
     def _login_username_password(self, stateToken, url):
         """ login to Okta with a username and password"""
         creds = self._get_username_password_creds()
-        response = requests.post(
+        response = self.req_session.post(
             url,
             json={'stateToken': stateToken, 'username': creds['username'], 'password': creds['password']},
             headers=self._get_headers()
@@ -85,7 +87,7 @@ class OktaClient(object):
 
     def _login_get_saml_response(self, url):
         """ return the base64 SAML value object from the SAML Response"""
-        response = requests.get(url, verify=self._verify_ssl_certs)
+        response = self.req_session.get(url, verify=self._verify_ssl_certs)
 
         saml_soup = BeautifulSoup(response.text, "html.parser")
         self._login_saml_form_action = saml_soup.find('form', id='appForm').get('action')
@@ -115,167 +117,88 @@ class OktaClient(object):
         else:
             raise RuntimeError('Unknown login status: ' + status)
 
-    def _get_aws_account_info(self):
-        s = requests.Session()
-        s.post(
+    def _get_aws_account_info(self, gimme_creds_server_url):
+        """ Submit the SAMLResponse and retreive the user's AWS accounts from the gimme_creds_server"""
+        self.req_session.post(
             self._login_saml_form_action,
             data = {'SAMLResponse':self._login_saml_response, 'RelayState':self._login_saml_relay_state},
             verify = self._verify_ssl_certs
         )
 
-        response = s.get('https://localhost:8443/api/v1/accounts', verify = self._verify_ssl_certs)
+        api_url = gimme_creds_server_url + '/api/v1/accounts'
+        response = self.req_session.get(api_url, verify = self._verify_ssl_certs)
+        self.aws_access = response.json()
 
-        print(self._login_saml_form_action)
+        # Throw an error if we didn't get any accounts back
+        if self.aws_access == []:
+            print("No AWS accounts found")
+            exit()
 
-        print(response.text)
+    def choose_app(self):
+        """ gets a list of available apps and
+        ask the user to select the app they want
+        to assume a roles for and returns the selection
+        """
+        #app_resp = self.get_app_links()
+        print("Pick an app:")
+        # print out the apps and let the user select
+        for i, app in enumerate(self.aws_access):
+            print('[', i, ']', app["name"])
 
-        exit()
+        selection = input("Selection: ")
 
+        # make sure the choice is valid
+        if int(selection) > len(self.aws_access):
+            print("You selected an invalid selection")
+            sys.exit(1)
 
-    # def get_app_links(self):
-    #     """ return appLinks obejct for the user """
-    #     headers = self._get_headers()
-    #
-    #     response = requests.get(
-    #         self._okta_org_url + '/users/' + self._user_id + '/appLinks',
-    #         headers=headers,
-    #         verify=True
-    #     )
-    #     app_resp = json.loads(response.text)
-    #
-    #     # create a list from appName = amazon_aws
-    #     apps = []
-    #     for app in app_resp:
-    #         if app['appName'] == 'amazon_aws':
-    #             apps.append(app)
-    #
-    #     if 'errorCode' in app_resp:
-    #         print("APP LINK ERROR: " + app_resp['errorSummary'], "Error Code ", app_resp['errorCode'])
-    #         sys.exit(2)
-    #
-    #     return apps
-    #
-    # def get_app(self):
-    #     """ gets a list of available apps and
-    #     ask the user to select the app they want
-    #     to assume a roles for and returns the selection
-    #     """
-    #     app_resp = self.get_app_links()
-    #     print("Pick an app:")
-    #     # print out the apps and let the user select
-    #     for i, app in enumerate(app_resp):
-    #         print('[', i, ']', app["label"])
-    #
-    #     selection = input("Selection: ")
-    #
-    #     # make sure the choice is valid
-    #     if int(selection) > len(app_resp):
-    #         print("You selected an invalid selection")
-    #         sys.exit(1)
-    #
-    #     # delete
-    #     return app_resp[int(selection)]["label"]
-    #
-    # def get_role(self, aws_appname):
-    #     """ gets a list of available roles and
-    #     ask the user to select the role they want
-    #     to assume and returns the selection
-    #     """
-    #     # get available roles for the AWS app
-    #     headers = self._get_headers()
-    #     response = requests.get(
-    #         self._okta_org_url + '/apps/?filter=user.id+eq+\"' +
-    #         self._user_id + '\"&expand=user/' + self._user_id + '&limit=200',
-    #         headers=headers,
-    #         verify=True
-    #     )
-    #     role_resp = json.loads(response.text)
-    #
-    #     # Check if this is a valid response
-    #     if 'errorCode' in role_resp:
-    #         print("ERROR: " + role_resp['errorSummary'], "Error Code ", role_resp['errorCode'])
-    #         sys.exit(2)
-    #
-    #     # print out roles for the app and let the uesr select
-    #     for app in role_resp:
-    #         if app['label'] == aws_appname:
-    #             print("Pick a role:")
-    #             roles = app['_embedded']['user']['profile']['samlRoles']
-    #
-    #             for i, role in enumerate(roles):
-    #                 print('[', i, ']:', role)
-    #             selection = input("Selection: ")
-    #
-    #             # make sure the choice is valid
-    #             if int(selection) > len(roles):
-    #                 print("You selected an invalid selection")
-    #                 sys.exit(1)
-    #
-    #             return roles[int(selection)]
-    #
-    # def get_app_url(self, aws_appname):
-    #     """ return the app link json for select aws app """
-    #     app_resp = self.get_app_links()
-    #
-    #     for app in app_resp:
-    #         if app['label'] == 'AWS_API':
-    #             print(app['linkUrl'])
-    #         if app['label'] == aws_appname:
-    #             return app
-    #
-    #     print("ERROR app not found:", aws_appname)
-    #     sys.exit(2)
-    #
-    # def get_idp_arn(self, app_id):
-    #     """ return the PrincipalArn based on the app instance id """
-    #     headers = self._get_headers()
-    #     response = requests.get(
-    #         self._okta_org_url + '/apps/' + app_id,
-    #         headers=headers,
-    #         verify=True
-    #     )
-    #     app_resp = json.loads(response.text)
-    #     return app_resp['settings']['app']['identityProviderArn']
-    #
-    # def get_role_arn(self, link_url, aws_rolename):
-    #     """ return the role arn for the selected role """
-    #     # decode the saml so we can find our arns
-    #     # https://aws.amazon.com/blogs/security/how-to-implement-federated-api-and-cli-access-using-saml-2-0-and-ad-fs/
-    #     aws_roles = []
-    #     root = et.fromstring(base64.b64decode(self.get_saml_assertion(link_url)))
-    #
-    #     for saml2attribute in root.iter('{urn:oasis:names:tc:SAML:2.0:assertion}Attribute'):
-    #         if saml2attribute.get('Name') == 'https://aws.amazon.com/SAML/Attributes/Role':
-    #             for saml2attributevalue in saml2attribute.iter(
-    #                     '{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue'):
-    #                 aws_roles.append(saml2attributevalue.text)
-    #
-    #     # grab the role ARNs that matches the role to assume
-    #     for aws_role in aws_roles:
-    #         chunks = aws_role.split(',')
-    #         if aws_rolename in chunks[1]:
-    #             return chunks[1]
-    #
-    #     # if you got this far something went wrong
-    #     print("ERROR no ARN found for", aws_rolename)
-    #     sys.exit(2)
-    #
-    # def get_saml_assertion(self, app_url):
-    #     """return the base64 SAML value object from the SAML Response"""
-    #     if self._saml_assertion is None:
-    #         response = requests.get(
-    #             app_url + '/?sessionToken=' + self._session_token,
-    #             verify=True
-    #         )
-    #
-    #         saml_soup = BeautifulSoup(response.text, "html.parser")
-    #         for inputtag in saml_soup.find_all('input'):
-    #             if inputtag.get('name') == 'SAMLResponse':
-    #                 self._saml_assertion = inputtag.get('value')
-    #
-    #     return self._saml_assertion
+        return self.aws_access[int(selection)]
 
+    def get_app_by_name(self, appname):
+        """ returns the app with the matching name"""
+        for i, app in enumerate(self.aws_access):
+            if app["name"] == appname:
+                return app
 
+    def get_role_by_name(self, app_info, rolename):
+        """ returns the role with the matching name"""
+        for i, role in enumerate(app_info['roles']):
+            if role["name"] == rolename:
+                return role
+
+    def choose_role(self, app_info):
+        """ gets a list of available roles and
+        asks the user to select the role they want to assume
+        """
+
+        print("Pick a role:")
+        # print out the roles and let the user select
+        for i, role in enumerate(app_info['roles']):
+            print('[', i, ']', role["name"])
+
+        selection = input("Selection: ")
+
+        # make sure the choice is valid
+        if int(selection) > len(app_info['roles']):
+            print("You selected an invalid selection")
+            sys.exit(1)
+
+        return app_info['roles'][int(selection)]
+
+    def get_saml_assertion(self, app_url):
+        """return the base64 SAML value object from the SAML Response"""
+        response = self.req_session.get(
+            app_url,
+            verify=self._verify_ssl_certs
+        )
+
+        # parse the SAML response from the HTML
+        saml_soup = BeautifulSoup(response.text, "html.parser")
+        for inputtag in saml_soup.find_all('input'):
+            if inputtag.get('name') == 'SAMLResponse':
+                self._saml_assertion = inputtag.get('value')
+
+        return self._saml_assertion
 
     def _get_username_password_creds(self):
         """Get's creds for Okta login from the user."""

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -25,15 +25,15 @@ class OktaClient(object):
        Okta API key and URL must be provided.
     """
 
-    def __init__(self, idp_entry_url, api_key, username, password):
+    def __init__(self, okta_org_url, api_key, username, password):
         """
-        :param idp_entry_url: Base URL string for Okta IDP.
+        :param okta_org_url: Base URL string for Okta IDP.
         :param api_key: Okta API key string.
         :param username: User's username string.
         :param password: User's password string.
         """
         self._okta_api_key = api_key
-        self._idp_entry_url = idp_entry_url
+        self._okta_org_url = okta_org_url
 
         self._user_id = None
         self._session_token = None
@@ -64,7 +64,7 @@ class OktaClient(object):
         """ gets the login response from Okta and returns the json response"""
         headers = self._get_headers()
         response = requests.post(
-            self._idp_entry_url + '/authn',
+            self._okta_org_url + '/authn',
             json={'username': self._username, 'password': self._password},
             headers=headers
         )
@@ -85,7 +85,7 @@ class OktaClient(object):
         headers = self._get_headers()
 
         response = requests.get(
-            self._idp_entry_url + '/users/' + self._user_id + '/appLinks',
+            self._okta_org_url + '/users/' + self._user_id + '/appLinks',
             headers=headers,
             verify=True
         )
@@ -132,7 +132,7 @@ class OktaClient(object):
         # get available roles for the AWS app
         headers = self._get_headers()
         response = requests.get(
-            self._idp_entry_url + '/apps/?filter=user.id+eq+\"' +
+            self._okta_org_url + '/apps/?filter=user.id+eq+\"' +
             self._user_id + '\"&expand=user/' + self._user_id + '&limit=200',
             headers=headers,
             verify=True
@@ -178,7 +178,7 @@ class OktaClient(object):
         """ return the PrincipalArn based on the app instance id """
         headers = self._get_headers()
         response = requests.get(
-            self._idp_entry_url + '/apps/' + app_id,
+            self._okta_org_url + '/apps/' + app_id,
             headers=headers,
             verify=True
         )

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -179,6 +179,9 @@ class OktaClient(object):
         saml_soup = BeautifulSoup(response.text, "html.parser")
         form_action = saml_soup.find('form').get('action')
 
+        saml_response = None
+        relay_state = None
+
         for inputtag in saml_soup.find_all('input'):
             if inputtag.get('name') == 'SAMLResponse':
                 saml_response = inputtag.get('value')

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -251,7 +251,7 @@ class OktaClient(object):
     def _build_factor_name(self, factor):
         """ Build the display name for a MFA factor based on the factor type"""
         if factor['factorType'] == 'push':
-            return factor['factorType'] + ": " + factor['profile']['deviceType'] + ": " + factor['profile']['name']
+            return "Okta Verify App: " + factor['profile']['deviceType'] + ": " + factor['profile']['name']
         elif factor['factorType'] == 'sms':
             return factor['factorType'] + ": " + factor['profile']['phoneNumber']
         elif factor['factorType'] == 'token:software:totp':

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -114,18 +114,32 @@ class OktaClient(object):
         if access_token is True:
             response_types.append('token')
 
-
         if 'authorization_server' not in kwargs:
             oauth_url = self._okta_org_url + '/oauth2/v1/authorize'
         else:
             oauth_url = self._okta_org_url + '/oauth2/' + kwargs['authorization_server'] + '/v1/authorize'
 
+        if 'redirect_uri' not in kwargs:
+            redirect_uri = 'http://localhost:8080/login'
+        else:
+            redirect_uri = kwargs['redirect_uri']
+
+        if 'nonce' not in kwargs:
+            nonce = 1
+        else:
+            nonce = kwargs['nonce']
+
+        if 'state' not in kwargs:
+            state = 'auth_oauth'
+        else:
+            state = kwargs['state']
+
         params = {
             'sessionToken': loginResponse['sessionToken'],
             'client_id': client_id,
-            'redirect_uri': 'http://localhost:8080/login',
-            'nonce': 1,
-            'state': 'auth_oauth',
+            'redirect_uri': redirect_uri,
+            'nonce': nonce,
+            'state': state,
             'response_type': ' '.join(response_types),
             'scope': ' '.join(scopes)
         }
@@ -355,57 +369,6 @@ class OktaClient(object):
         else:
             print("Unknown MFA type: " + factor['factorType'])
             return ""
-
-    def choose_app(self, aws_info):
-        """ gets a list of available apps and
-        ask the user to select the app they want
-        to assume a roles for and returns the selection
-        """
-
-        print("Pick an app:")
-        # print out the apps and let the user select
-        for i, app in enumerate(aws_info):
-            print('[', i, ']', app["name"])
-
-        selection = input("Selection: ")
-
-        # make sure the choice is valid
-        if int(selection) > len(aws_info):
-            print("You made an invalid selection")
-            sys.exit(1)
-
-        return aws_info[int(selection)]
-
-    def get_app_by_name(self, aws_info, appname):
-        """ returns the app with the matching name"""
-        for i, app in enumerate(aws_info):
-            if app["name"] == appname:
-                return app
-
-    def get_role_by_name(self, app_info, rolename):
-        """ returns the role with the matching name"""
-        for i, role in enumerate(app_info['roles']):
-            if role["name"] == rolename:
-                return role
-
-    def choose_role(self, app_info):
-        """ gets a list of available roles and
-        asks the user to select the role they want to assume
-        """
-
-        print("Pick a role:")
-        # print out the roles and let the user select
-        for i, role in enumerate(app_info['roles']):
-            print('[', i, ']', role["name"])
-
-        selection = input("Selection: ")
-
-        # make sure the choice is valid
-        if int(selection) > len(app_info['roles']):
-            print("You made an invalid selection")
-            sys.exit(1)
-
-        return app_info['roles'][int(selection)]
 
     def _get_username_password_creds(self):
         """Get's creds for Okta login from the user."""

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -12,11 +12,13 @@ See the License for the specific language governing permissions and* limitations
 import base64
 import json
 import sys
+import getpass
 import xml.etree.ElementTree as et
+from urllib.parse import urlparse
+from urllib.parse import parse_qs
 
 import requests
 from bs4 import BeautifulSoup
-
 
 class OktaClient(object):
     """
@@ -25,200 +27,271 @@ class OktaClient(object):
        Okta API key and URL must be provided.
     """
 
-    def __init__(self, okta_org_url, api_key, username, password):
+    def __init__(self, okta_org_url, verify_ssl_certs=True):
         """
         :param okta_org_url: Base URL string for Okta IDP.
-        :param api_key: Okta API key string.
-        :param username: User's username string.
-        :param password: User's password string.
+        :param verify_ssl_certs: Enable/disable SSL verification
         """
-        self._okta_api_key = api_key
         self._okta_org_url = okta_org_url
+        self._verify_ssl_certs = verify_ssl_certs
 
-        self._user_id = None
-        self._session_token = None
-        self._saml_assertion = None
+        self._server_embed_link = None
+        self._username = None
 
-        # Unfortunately we have to store credentials in memory since we'll need them more than once.
+        self._login_saml_response = None
+        self._login_saml_form_action = None
+        self._login_saml_relay_state = None
+
+        # self._get_aws_info()
+
+    def set_username(self, username):
         self._username = username
-        self._password = password
 
-        self._get_login_response()
+    def login(self, embed_link):
+        """ set the user credentials"""
+        self._server_embed_link = embed_link
+        self._start_login_flow()
+        self._get_aws_account_info()
 
     def _get_headers(self):
-        """sets the default header"""
+        """sets the default headers"""
         headers = {
             'Accept': 'application/json',
-            'Content-Type': 'application/json',
-            'Authorization': 'SSWS ' + self._okta_api_key}
+            'Content-Type': 'application/json' }
         return headers
 
-    # def _get_session_token(self):
-    #     if self._session_token is not None:
-    #         return self._session_token
-    #     else:
-    #         self._get_login_response()
-    #         return self._session_token
+    def _start_login_flow(self):
+        """ gets the starts the authentication flow with Okta"""
+        response = requests.get(self._server_embed_link , allow_redirects=False)
+        url_parse_results = urlparse(response.headers['Location'])
+        stateToken =  parse_qs(url_parse_results.query)['stateToken'][0]
 
-    def _get_login_response(self):
-        """ gets the login response from Okta and returns the json response"""
-        headers = self._get_headers()
         response = requests.post(
             self._okta_org_url + '/authn',
-            json={'username': self._username, 'password': self._password},
-            headers=headers
+            json={'stateToken': stateToken},
+            headers=self._get_headers()
         )
+        self._next_login_step(stateToken, response.json())
 
-        login_data = response.json()
+    def _login_username_password(self, stateToken, url):
+        """ login to Okta with a username and password"""
+        creds = self._get_username_password_creds()
+        response = requests.post(
+            url,
+            json={'stateToken': stateToken, 'username': creds['username'], 'password': creds['password']},
+            headers=self._get_headers()
+        )
+        self._next_login_step(stateToken, response.json())
 
+    def _login_get_saml_response(self, url):
+        """ return the base64 SAML value object from the SAML Response"""
+        response = requests.get(url, verify=self._verify_ssl_certs)
+
+        saml_soup = BeautifulSoup(response.text, "html.parser")
+        self._login_saml_form_action = saml_soup.find('form', id='appForm').get('action')
+        for inputtag in saml_soup.find_all('input'):
+            if inputtag.get('name') == 'SAMLResponse':
+                self._login_saml_response = inputtag.get('value')
+            elif inputtag.get('name') == 'RelayState':
+                self._login_saml_relay_state = inputtag.get('value')
+
+    def _next_login_step(self, stateToken, login_data):
+        """ decide what the next step in the login process is"""
         if 'errorCode' in login_data:
             print("LOGIN ERROR: " + login_data['errorSummary'], "Error Code ", login_data['errorCode'])
             sys.exit(2)
-        elif login_data['status'] == 'MFA_REQUIRED':
+
+        status = login_data['status']
+
+        if status == 'UNAUTHENTICATED':
+            self._login_username_password(stateToken, login_data['_links']['next']['href'])
+        elif status == 'SUCCESS':
+            self._login_get_saml_response(login_data['_links']['next']['href'])
+        elif status == 'MFA_ENROLL':
+            print("You must enroll in MFA before using this tool.")
+            sys.exit(2)
+        elif status == 'MFA_REQUIRED':
             raise NotImplementedError('Okta MFA not yet implemented.')
+        else:
+            raise RuntimeError('Unknown login status: ' + status)
 
-        self._user_id = login_data['_embedded']['user']['id']
-        self._session_token = login_data['sessionToken']
-
-    def get_app_links(self):
-        """ return appLinks obejct for the user """
-        headers = self._get_headers()
-
-        response = requests.get(
-            self._okta_org_url + '/users/' + self._user_id + '/appLinks',
-            headers=headers,
-            verify=True
+    def _get_aws_account_info(self):
+        s = requests.Session()
+        s.post(
+            self._login_saml_form_action,
+            data = {'SAMLResponse':self._login_saml_response, 'RelayState':self._login_saml_relay_state},
+            verify = self._verify_ssl_certs
         )
-        app_resp = json.loads(response.text)
 
-        # create a list from appName = amazon_aws
-        apps = []
-        for app in app_resp:
-            if app['appName'] == 'amazon_aws':
-                apps.append(app)
+        response = s.get('https://localhost:8443/api/v1/accounts', verify = self._verify_ssl_certs)
 
-        if 'errorCode' in app_resp:
-            print("APP LINK ERROR: " + app_resp['errorSummary'], "Error Code ", app_resp['errorCode'])
-            sys.exit(2)
+        print(self._login_saml_form_action)
 
-        return apps
+        print(response.text)
 
-    def get_app(self):
-        """ gets a list of available apps and
-        ask the user to select the app they want
-        to assume a roles for and returns the selection
-        """
-        app_resp = self.get_app_links()
-        print("Pick an app:")
-        # print out the apps and let the user select
-        for i, app in enumerate(app_resp):
-            print('[', i, ']', app["label"])
+        exit()
 
-        selection = input("Selection: ")
 
-        # make sure the choice is valid
-        if int(selection) > len(app_resp):
-            print("You selected an invalid selection")
+    # def get_app_links(self):
+    #     """ return appLinks obejct for the user """
+    #     headers = self._get_headers()
+    #
+    #     response = requests.get(
+    #         self._okta_org_url + '/users/' + self._user_id + '/appLinks',
+    #         headers=headers,
+    #         verify=True
+    #     )
+    #     app_resp = json.loads(response.text)
+    #
+    #     # create a list from appName = amazon_aws
+    #     apps = []
+    #     for app in app_resp:
+    #         if app['appName'] == 'amazon_aws':
+    #             apps.append(app)
+    #
+    #     if 'errorCode' in app_resp:
+    #         print("APP LINK ERROR: " + app_resp['errorSummary'], "Error Code ", app_resp['errorCode'])
+    #         sys.exit(2)
+    #
+    #     return apps
+    #
+    # def get_app(self):
+    #     """ gets a list of available apps and
+    #     ask the user to select the app they want
+    #     to assume a roles for and returns the selection
+    #     """
+    #     app_resp = self.get_app_links()
+    #     print("Pick an app:")
+    #     # print out the apps and let the user select
+    #     for i, app in enumerate(app_resp):
+    #         print('[', i, ']', app["label"])
+    #
+    #     selection = input("Selection: ")
+    #
+    #     # make sure the choice is valid
+    #     if int(selection) > len(app_resp):
+    #         print("You selected an invalid selection")
+    #         sys.exit(1)
+    #
+    #     # delete
+    #     return app_resp[int(selection)]["label"]
+    #
+    # def get_role(self, aws_appname):
+    #     """ gets a list of available roles and
+    #     ask the user to select the role they want
+    #     to assume and returns the selection
+    #     """
+    #     # get available roles for the AWS app
+    #     headers = self._get_headers()
+    #     response = requests.get(
+    #         self._okta_org_url + '/apps/?filter=user.id+eq+\"' +
+    #         self._user_id + '\"&expand=user/' + self._user_id + '&limit=200',
+    #         headers=headers,
+    #         verify=True
+    #     )
+    #     role_resp = json.loads(response.text)
+    #
+    #     # Check if this is a valid response
+    #     if 'errorCode' in role_resp:
+    #         print("ERROR: " + role_resp['errorSummary'], "Error Code ", role_resp['errorCode'])
+    #         sys.exit(2)
+    #
+    #     # print out roles for the app and let the uesr select
+    #     for app in role_resp:
+    #         if app['label'] == aws_appname:
+    #             print("Pick a role:")
+    #             roles = app['_embedded']['user']['profile']['samlRoles']
+    #
+    #             for i, role in enumerate(roles):
+    #                 print('[', i, ']:', role)
+    #             selection = input("Selection: ")
+    #
+    #             # make sure the choice is valid
+    #             if int(selection) > len(roles):
+    #                 print("You selected an invalid selection")
+    #                 sys.exit(1)
+    #
+    #             return roles[int(selection)]
+    #
+    # def get_app_url(self, aws_appname):
+    #     """ return the app link json for select aws app """
+    #     app_resp = self.get_app_links()
+    #
+    #     for app in app_resp:
+    #         if app['label'] == 'AWS_API':
+    #             print(app['linkUrl'])
+    #         if app['label'] == aws_appname:
+    #             return app
+    #
+    #     print("ERROR app not found:", aws_appname)
+    #     sys.exit(2)
+    #
+    # def get_idp_arn(self, app_id):
+    #     """ return the PrincipalArn based on the app instance id """
+    #     headers = self._get_headers()
+    #     response = requests.get(
+    #         self._okta_org_url + '/apps/' + app_id,
+    #         headers=headers,
+    #         verify=True
+    #     )
+    #     app_resp = json.loads(response.text)
+    #     return app_resp['settings']['app']['identityProviderArn']
+    #
+    # def get_role_arn(self, link_url, aws_rolename):
+    #     """ return the role arn for the selected role """
+    #     # decode the saml so we can find our arns
+    #     # https://aws.amazon.com/blogs/security/how-to-implement-federated-api-and-cli-access-using-saml-2-0-and-ad-fs/
+    #     aws_roles = []
+    #     root = et.fromstring(base64.b64decode(self.get_saml_assertion(link_url)))
+    #
+    #     for saml2attribute in root.iter('{urn:oasis:names:tc:SAML:2.0:assertion}Attribute'):
+    #         if saml2attribute.get('Name') == 'https://aws.amazon.com/SAML/Attributes/Role':
+    #             for saml2attributevalue in saml2attribute.iter(
+    #                     '{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue'):
+    #                 aws_roles.append(saml2attributevalue.text)
+    #
+    #     # grab the role ARNs that matches the role to assume
+    #     for aws_role in aws_roles:
+    #         chunks = aws_role.split(',')
+    #         if aws_rolename in chunks[1]:
+    #             return chunks[1]
+    #
+    #     # if you got this far something went wrong
+    #     print("ERROR no ARN found for", aws_rolename)
+    #     sys.exit(2)
+    #
+    # def get_saml_assertion(self, app_url):
+    #     """return the base64 SAML value object from the SAML Response"""
+    #     if self._saml_assertion is None:
+    #         response = requests.get(
+    #             app_url + '/?sessionToken=' + self._session_token,
+    #             verify=True
+    #         )
+    #
+    #         saml_soup = BeautifulSoup(response.text, "html.parser")
+    #         for inputtag in saml_soup.find_all('input'):
+    #             if inputtag.get('name') == 'SAMLResponse':
+    #                 self._saml_assertion = inputtag.get('value')
+    #
+    #     return self._saml_assertion
+
+
+
+    def _get_username_password_creds(self):
+        """Get's creds for Okta login from the user."""
+        # Check to see if the username arg has been set, if so use that
+        if self._username is not None:
+            username = self._username
+        # Otherwise just ask the user
+        else:
+            username = input("Email address: ")
+        # Set prompt to include the user name, since username could be set
+        # via OKTA_USERNAME env and user might not remember.
+        passwd_prompt = "Password for {}: ".format(username)
+        password = getpass.getpass(prompt=passwd_prompt)
+        if len(password) == 0:
+            print("Password must be provided.")
             sys.exit(1)
+        creds = {'username': username, 'password': password }
 
-        # delete
-        return app_resp[int(selection)]["label"]
-
-    def get_role(self, aws_appname):
-        """ gets a list of available roles and
-        ask the user to select the role they want
-        to assume and returns the selection
-        """
-        # get available roles for the AWS app
-        headers = self._get_headers()
-        response = requests.get(
-            self._okta_org_url + '/apps/?filter=user.id+eq+\"' +
-            self._user_id + '\"&expand=user/' + self._user_id + '&limit=200',
-            headers=headers,
-            verify=True
-        )
-        role_resp = json.loads(response.text)
-
-        # Check if this is a valid response
-        if 'errorCode' in role_resp:
-            print("ERROR: " + role_resp['errorSummary'], "Error Code ", role_resp['errorCode'])
-            sys.exit(2)
-
-        # print out roles for the app and let the uesr select
-        for app in role_resp:
-            if app['label'] == aws_appname:
-                print("Pick a role:")
-                roles = app['_embedded']['user']['profile']['samlRoles']
-
-                for i, role in enumerate(roles):
-                    print('[', i, ']:', role)
-                selection = input("Selection: ")
-
-                # make sure the choice is valid
-                if int(selection) > len(roles):
-                    print("You selected an invalid selection")
-                    sys.exit(1)
-
-                return roles[int(selection)]
-
-    def get_app_url(self, aws_appname):
-        """ return the app link json for select aws app """
-        app_resp = self.get_app_links()
-
-        for app in app_resp:
-            if app['label'] == 'AWS_API':
-                print(app['linkUrl'])
-            if app['label'] == aws_appname:
-                return app
-
-        print("ERROR app not found:", aws_appname)
-        sys.exit(2)
-
-    def get_idp_arn(self, app_id):
-        """ return the PrincipalArn based on the app instance id """
-        headers = self._get_headers()
-        response = requests.get(
-            self._okta_org_url + '/apps/' + app_id,
-            headers=headers,
-            verify=True
-        )
-        app_resp = json.loads(response.text)
-        return app_resp['settings']['app']['identityProviderArn']
-
-    def get_role_arn(self, link_url, aws_rolename):
-        """ return the role arn for the selected role """
-        # decode the saml so we can find our arns
-        # https://aws.amazon.com/blogs/security/how-to-implement-federated-api-and-cli-access-using-saml-2-0-and-ad-fs/
-        aws_roles = []
-        root = et.fromstring(base64.b64decode(self.get_saml_assertion(link_url)))
-
-        for saml2attribute in root.iter('{urn:oasis:names:tc:SAML:2.0:assertion}Attribute'):
-            if saml2attribute.get('Name') == 'https://aws.amazon.com/SAML/Attributes/Role':
-                for saml2attributevalue in saml2attribute.iter(
-                        '{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue'):
-                    aws_roles.append(saml2attributevalue.text)
-
-        # grab the role ARNs that matches the role to assume
-        for aws_role in aws_roles:
-            chunks = aws_role.split(',')
-            if aws_rolename in chunks[1]:
-                return chunks[1]
-
-        # if you got this far something went wrong
-        print("ERROR no ARN found for", aws_rolename)
-        sys.exit(2)
-
-    def get_saml_assertion(self, app_url):
-        """return the base64 SAML value object from the SAML Response"""
-        if self._saml_assertion is None:
-            response = requests.get(
-                app_url + '/?sessionToken=' + self._session_token,
-                verify=True
-            )
-
-            saml_soup = BeautifulSoup(response.text, "html.parser")
-            for inputtag in saml_soup.find_all('input'):
-                if inputtag.get('name') == 'SAMLResponse':
-                    self._saml_assertion = inputtag.get('value')
-
-        return self._saml_assertion
+        return creds

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -119,7 +119,13 @@ class OktaClient(object):
             headers=self._get_headers(),
             verify=self._verify_ssl_certs
         )
-        return {'stateToken': stateToken, 'apiResponse': response.json()}
+
+        login_data = response.json()
+        if 'errorCode' in login_data:
+            print("LOGIN ERROR: " + login_data['errorSummary'], "Error Code ", login_data['errorCode'])
+            sys.exit(2)
+
+        return {'stateToken': stateToken, 'apiResponse': login_data}
 
     def _login_send_sms(self, stateToken, factor):
         """ Send SMS message for second factor authentication"""

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -376,7 +376,6 @@ class OktaClient(object):
         if saml_response is None:
             # We didn't get a SAML response.  Were we redirected to an MFA login page?
             if hasattr(saml_soup.title, 'string') and re.match(".* - Extra Verification$", saml_soup.title.string):
-                print("MFA required.")
                 # extract the stateToken from the Javascript code in the page and step up to MFA
                 stateToken = decode(re.search(r"var stateToken = '(.*)';", response.text).group(1), "unicode-escape")
                 apiResponse = self.stepup_auth(url, stateToken)

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -45,6 +45,11 @@ class OktaClient(object):
 
         self._username = None
 
+        self._use_oauth_access_token = False
+        self._use_oauth_id_token = False
+        self._oauth_access_token = None
+        self._oauth_id_token = None
+
         # Allow up to 5 retries on requests to Okta in case we have network issues
         self._http_client = requests.Session()
         retries = Retry(total=5, backoff_factor=1,
@@ -53,6 +58,12 @@ class OktaClient(object):
 
     def set_username(self, username):
         self._username = username
+
+    def use_oauth_access_token(self, val=True):
+        self._use_oauth_access_token = val
+
+    def use_oauth_id_token(self, val=True):
+        self._use_oauth_id_token = val
 
     def stepup_auth(self, embed_link):
         """ Login to Okta using the Step-up authentication flow"""
@@ -158,8 +169,10 @@ class OktaClient(object):
         tokens = {}
         if 'access_token' in query_result:
             tokens['access_token'] = query_result['access_token'][0]
+            self._oauth_access_token = query_result['access_token'][0]
         if 'id_token' in query_result:
             tokens['id_token'] = query_result['id_token'][0]
+            self._oauth_id_token = query_result['id_token'][0]
 
         return tokens
 
@@ -323,18 +336,54 @@ class OktaClient(object):
 
     def get(self, url, **kwargs):
         """ Retrieve resource that is protected by Okta """
+        if self._use_oauth_access_token is True:
+            if 'headers' not in kwargs:
+                kwargs['headers'] = {}
+            kwargs['headers']['Authorization'] = self._oauth_access_token
+
+        if self._use_oauth_id_token is True:
+            if 'headers' not in kwargs:
+                kwargs['headers'] = {}
+            kwargs['headers']['Authorization'] = self._oauth_id_token
         return self._http_client.get(url, **kwargs )
 
     def post(self, url, **kwargs):
         """ Create resource that is protected by Okta """
+        if self._use_oauth_access_token is True:
+            if 'headers' not in kwargs:
+                kwargs['headers'] = {}
+            kwargs['headers']['Authorization'] = self._oauth_access_token
+
+        if self._use_oauth_id_token is True:
+            if 'headers' not in kwargs:
+                kwargs['headers'] = {}
+            kwargs['headers']['Authorization'] = self._oauth_id_token
         return self._http_client.post(url, **kwargs )
 
     def put(self, url, **kwargs):
         """ Modify resource that is protected by Okta """
+        if self._use_oauth_access_token is True:
+            if 'headers' not in kwargs:
+                kwargs['headers'] = {}
+            kwargs['headers']['Authorization'] = self._oauth_access_token
+
+        if self._use_oauth_id_token is True:
+            if 'headers' not in kwargs:
+                kwargs['headers'] = {}
+            kwargs['headers']['Authorization'] = self._oauth_id_token
         return self._http_client.put(url, **kwargs )
 
     def delete(self, url, **kwargs):
         """ Delete resource that is protected by Okta """
+        if self._use_oauth_access_token is True:
+            if 'headers' not in kwargs:
+                kwargs['headers'] = {}
+            kwargs['headers']['Authorization'] = self._oauth_access_token
+
+        if self._use_oauth_id_token is True:
+            if 'headers' not in kwargs:
+                kwargs['headers'] = {}
+            kwargs['headers']['Authorization'] = self._oauth_id_token
         return self._http_client.delete(url, **kwargs )
 
     def _choose_factor(self, factors):

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -191,12 +191,14 @@ class OktaClient(object):
         """ return the base64 SAML value object from the SAML Response"""
         response = self.req_session.get(url, verify=self._verify_ssl_certs)
 
-        saml_soup = BeautifulSoup(response.text, "html.parser")
         form_action = saml_soup.find('form').get('action')
-
         saml_response = None
         relay_state = None
+        form_action = None
 
+        saml_soup = BeautifulSoup(response.text, "html.parser")
+        if saml_soup.find('form') is not None:
+            form_action = saml_soup.find('form').get('action')
         for inputtag in saml_soup.find_all('input'):
             if inputtag.get('name') == 'SAMLResponse':
                 saml_response = inputtag.get('value')

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -19,6 +19,9 @@ from urllib.parse import urlparse
 from urllib.parse import parse_qs
 
 import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
 from bs4 import BeautifulSoup
 
 class OktaClient(object):
@@ -41,7 +44,10 @@ class OktaClient(object):
 
         self.aws_access = None
 
+        # Allow up to 5 retries on requests to Okta in case we have network issues
         self.req_session = requests.Session()
+        retries = Retry(total=5, backoff_factor=1, method_whitelist=['GET', 'POST'])
+        self.req_session.mount('https://', HTTPAdapter(max_retries=retries))
 
     def set_username(self, username):
         self._username = username

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -9,6 +9,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and* limitations under the License.*
 """
+import re
 import time
 import base64
 import json
@@ -421,6 +422,7 @@ class OktaClient(object):
 
     def _get_username_password_creds(self):
         """Get's creds for Okta login from the user."""
+
         # Check to see if the username arg has been set, if so use that
         if self._username is not None:
             username = self._username
@@ -428,6 +430,12 @@ class OktaClient(object):
         else:
             username = input("Email address: ")
             self._username = username
+
+        # The Okta username must be an email address
+        if not re.match("[^@]+@[^@]+\.[^@]+", username):
+            print("Okta username must be an email address.")
+            sys.exit(1)
+
         # Set prompt to include the user name, since username could be set
         # via OKTA_USERNAME env and user might not remember.
         passwd_prompt = "Password for {}: ".format(username)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,4 @@ bs4
 cerberus-python-client >= 0.2.0
 configparser >= 3.5
 mock
-nose
 requests
-responses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-argparse 
+argparse
 boto3
 bs4
 cerberus-python-client >= 0.2.0
@@ -6,3 +6,4 @@ configparser >= 3.5
 mock
 nose
 requests
+responses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
+git+https://github.com/okta/okta-sdk-python#egg=okta
 argparse
 boto3
 bs4
-cerberus-python-client >= 0.2.0
 configparser >= 3.5
-mock
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/okta/okta-sdk-python#egg=okta
+okta
 argparse
 boto3
 bs4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+moto>=0.4.31
+nose>=1.3.7
+coverage>=4.2
+responses

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,3 +3,4 @@ moto>=0.4.31
 nose>=1.3.7
 coverage>=4.2
 responses
+mock

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='gimme aws creds',
-    version='0.1.5',
+    version='0.1.6',
     install_requires=requirements,
     author='Ann Wallace',
     author_email='ann.wallace@nike.com',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='gimme aws creds',
-    version='0.1.6',
+    version='0.1.7',
     install_requires=requirements,
     author='Ann Wallace',
     author_email='ann.wallace@nike.com',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,15 +21,8 @@ class TestConfig(unittest.TestCase):
         self.config.clean_up()
 
     @patch('argparse.ArgumentParser.parse_args',
-           return_value=argparse.Namespace(username='ann', configure=False, profile=None))
+           return_value=argparse.Namespace(username='ann', configure=False, profile=None, insecure=False))
     def test_get_args_username(self, mock_arg):
         """Test to make sure username gets returned"""
         self.config.get_args()
         assert_equals(self.config.username, 'ann')
-
-    @patch('getpass.getpass', return_value='1234qwert')
-    @patch('builtins.input', return_value='ann')
-    def test_get_password(self, mock_pass, mock_input):
-        """Test that password gets set properly"""
-        self.config.get_user_creds()
-        assert_equals(self.config.password, '1234qwert')

--- a/tests/test_okta_client.py
+++ b/tests/test_okta_client.py
@@ -3,7 +3,9 @@ import json
 import unittest
 
 import requests
+import responses
 from mock import patch
+from nose.tools import assert_equals
 
 from gimme_aws_creds.okta import OktaClient
 

--- a/tests/test_okta_client.py
+++ b/tests/test_okta_client.py
@@ -15,8 +15,8 @@ class TestOktaClient(unittest.TestCase):
     def setUp(self):
         """Set up for the unit tests"""
         self.okta_api_key = 'XXXXXX'
-        self.idp_entry_url = 'https://example.okta.com'
-        self.client = self.setUp_client(self.idp_entry_url, self.okta_api_key)
+        self.okta_org_url = 'https://example.okta.com'
+        self.client = self.setUp_client(self.okta_org_url, self.okta_api_key)
         # self.login_resp = {
         #     "_embedded": {
         #         "user": {
@@ -41,9 +41,9 @@ class TestOktaClient(unittest.TestCase):
         ]
 
     @patch('gimme_aws_creds.okta.OktaClient._get_login_response')
-    def setUp_client(self, idp_entry_url, okta_api_key, mock_login):
+    def setUp_client(self, okta_org_url, okta_api_key, mock_login):
         mock_login.return_value = None
-        client = OktaClient(idp_entry_url, okta_api_key, 'username', 'password')
+        client = OktaClient(okta_org_url, okta_api_key, 'username', 'password')
         client._user_id = '00000'
         client._session_token = '20111ZTiraxruMoaA3cQh7RgG9lMqPiVk'
         return client


### PR DESCRIPTION
To avoid sharing an Okta API key with a large number of people, I built a lambda in AWS that handles the interaction with Okta.  The client authenticates with the lambda using OAuth, eliminating the need to share any private information with users.  If you don't want to run the lambda and have access to an API key, calls to Okta can still be done directly in the client.

In addition, Okta MFA policies (both application and domain level) are now supported with the following factors:

- Okta Verify (both push and OTP)
- Google Authenticator
- OTP via SMS
- OTP via Voice call