### PR TITLE
Enumerate saml roles from assertion rather than okta api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,8 @@ ENV/
 
 # IntelliJ IDE
 .idea/
+
+# Vim swap files
+*.swp
+*.swo
+*~

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ A configuration wizard will prompt you to enter the necessary configuration para
 - client_id - OAuth client ID for gimme-creds-lambda
 - gimme_creds_server - URL for gimme-creds-lambda or 'internal' for direct interaction with the Okta APIs (`OKTA_API_KEY` environment variable required)
 - write_aws_creds - y or n - If yes, the AWS credentials will be written to `~/.aws/credentials` otherwise it will be written to stdout.
-- cred_profile - If writing to the AWS cred file, this sets the name of the AWS credential profile.
+- cred_profile - If writing to the AWS cred file, this sets the name of the AWS credential profile.  The reserved word 'role' will use the name component of the role arn as the profile name.  i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [okta-1234-role] in the aws credentials file
 - aws_appname - This is optional. The Okta AWS App name, which has the role you want to assume.
-- aws_rolename - This is optional. The name of the role you want temporary AWS credentials for.
+- aws_rolename - This is optional. The name of the role you want temporary AWS credentials for.  The reserved word 'all' can be used to get and store credentials for every role the user is permissioned for.
 
 ## Usage
 

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -16,6 +16,11 @@ import os
 import re
 import sys
 from os.path import expanduser
+from collections import namedtuple
+
+# For enumerating saml roles
+import base64
+import xml.etree.ElementTree as ET
 
 # extras
 import boto3
@@ -26,6 +31,7 @@ from okta.framework.OktaError import OktaError
 from gimme_aws_creds.config import Config
 from gimme_aws_creds.okta import OktaClient
 
+RoleSet = namedtuple('RoleSet', 'idp, role')
 
 class GimmeAWSCreds(object):
     """
@@ -61,14 +67,12 @@ class GimmeAWSCreds(object):
            write_aws_creds = Option to write creds to ~/.aws/credentials
            cred_profile = Use DEFAULT or Role as the profile in ~/.aws/credentials
            aws_appname = (optional) Okta AWS App Name
-           aws_rolename =  (optional) Okta Role Name
+           aws_rolename =  (optional) AWS Role Name. 'ALL' will retrieve all roles.
     """
     FILE_ROOT = expanduser("~")
     AWS_CONFIG = FILE_ROOT + '/.aws/credentials'
 
     def __init__(self):
-        self.idp_arn = None
-        self.role_arn = None
 
     #  this is modified code from https://github.com/nimbusscale/okta_aws_login
     def _write_aws_creds(self, profile, access_key, secret_key, token):
@@ -96,13 +100,39 @@ class GimmeAWSCreds(object):
         with open(self.AWS_CONFIG, 'w+') as configfile:
             config.write(configfile)
 
-    def _get_sts_creds(self, assertion, duration=3600):
+    def _enumerate_saml_roles(self, assertion):
+        """ using the assertion and arns return aws sts creds """
+        role_pairs = []
+        root = ET.fromstring(base64.b64decode(assertion))
+        for saml2_attribute in root.iter('{urn:oasis:names:tc:SAML:2.0:assertion}Attribute'):
+            if (saml2_attribute.get('Name') == 'https://aws.amazon.com/SAML/Attributes/Role'):
+                for saml2_attribute_value in saml2_attribute.iter('{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue'):
+                    role_pairs.append(saml2_attribute_value.text)
+
+        # Normalize pieces of string; order may vary per AWS sample
+        result = []
+        for role_pair in role_pairs:
+            idp, role = None, None
+            for field in role_pair.split(','):
+                if 'saml-provider' in field:
+                    idp = field
+                elif 'role' in field:
+                    role = field
+            if not idp or not role:
+                print('Parsing error on {}'.format(role_pair))
+                exit()
+            else:
+                result.append(RoleSet(idp=idp, role=role))
+
+        return result
+
+    def _get_sts_creds(self, assertion, idp, role, duration=3600):
         """ using the assertion and arns return aws sts creds """
         client = boto3.client('sts')
 
         response = client.assume_role_with_saml(
-            RoleArn=self.role_arn,
-            PrincipalArn=self.idp_arn,
+            RoleArn=role,
+            PrincipalArn=idp,
             SAMLAssertion=assertion,
             DurationSeconds=duration
         )
@@ -229,31 +259,22 @@ class GimmeAWSCreds(object):
                 return app
 
     @staticmethod
-    def _get_role_by_name(app_info, rolename):
-        """ returns the role with the matching name"""
-        for i, role in enumerate(app_info['roles']):
-            if role["name"] == rolename:
-                return role
-
-    @staticmethod
-    def _choose_role(app_info):
+    def _choose_role(roles):
         """ gets a list of available roles and
         asks the user to select the role they want to assume
         """
-
         print("Pick a role:")
         # print out the roles and let the user select
-        for i, role in enumerate(app_info['roles']):
-            print('[', i, ']', role["name"])
+        for i, role in enumerate(roles):
+            print('[{}] {}'.format(i, role.role))
 
         selection = input("Selection: ")
 
         # make sure the choice is valid
-        if int(selection) > len(app_info['roles']):
+        if int(selection) > len(roles) - 1:
             print("You made an invalid selection")
             sys.exit(1)
-
-        return app_info['roles'][int(selection)]
+        return roles[int(selection)].role
 
     def run(self):
         """ Pulling it all together to make the CLI """
@@ -288,7 +309,7 @@ class GimmeAWSCreds(object):
             # Authenticate with Okta
             auth_result = okta.auth_session()
 
-            print("Authentication Success! Getting AWS Accounts", end='', flush=True)
+            print("Authentication Success! Getting AWS Accounts")
             aws_results = self._get_aws_account_info(conf_dict['okta_org_url'], config.api_key, auth_result['username'])
 
         # Use the gimme_creds_lambda service
@@ -318,49 +339,54 @@ class GimmeAWSCreds(object):
         if not conf_dict.get('aws_appname'):
             aws_app = self._choose_app(aws_results)
         else:
-            aws_app = self._get_app_by_name(
-                aws_results, conf_dict['aws_appname'])
-
-        if not conf_dict.get('aws_rolename'):
-            aws_role = self._choose_role(aws_app)
-        else:
-            aws_role = self._get_role_by_name(
-                aws_app, conf_dict['aws_rolename'])
-
-        # Get the the identityProviderArn from the aws app
-        self.idp_arn = aws_app['identityProviderArn']
-
-        # Get the role ARNs
-        self.role_arn = aws_role['arn']
+            aws_app = self._get_app_by_name(aws_results, conf_dict['aws_appname'])
 
         saml_data = okta.get_saml_response(aws_app['links']['appLink'])
-        aws_creds = self._get_sts_creds(saml_data['SAMLResponse'])
+        roles = self._enumerate_saml_roles(saml_data['SAMLResponse'])
 
-        # check if write_aws_creds is true if so
-        # get the profile name and write out the file
-        if str(conf_dict['write_aws_creds']) == 'True':
-            print('writing to ', self.AWS_CONFIG)
-            # set the profile name
-            if conf_dict['cred_profile'].lower() == 'default':
-                profile_name = 'default'
-            elif conf_dict['cred_profile'].lower() == 'role':
-                profile_name = conf_dict['aws_rolename']
-            else:
-                profile_name = conf_dict['cred_profile']
-
-            # Write out the AWS Config file
-            self._write_aws_creds(
-                profile_name,
-                aws_creds['AccessKeyId'],
-                aws_creds['SecretAccessKey'],
-                aws_creds['SessionToken']
-            )
+        aws_role = ''
+        if not conf_dict.get('aws_rolename'):
+            aws_role = self._choose_role(roles)
         else:
-            # Print out temporary AWS credentials.  Credentials are printed to stderr to simplify
-            # redirection for use in automated scripts
-            print("export AWS_ACCESS_KEY_ID=" + aws_creds['AccessKeyId'], file=sys.stderr)
-            print("export AWS_SECRET_ACCESS_KEY=" + aws_creds['SecretAccessKey'], file=sys.stderr)
-            print("export AWS_SESSION_TOKEN=" + aws_creds['SessionToken'], file=sys.stderr)
+            aws_role = conf_dict.get('aws_rolename')
+
+        for i, role in enumerate(roles):
+            # Skip irrelevant roles
+            if aws_role != 'all' and aws_role not in role.role:
+                continue
+
+            aws_creds = self._get_sts_creds(saml_data['SAMLResponse'], role.idp, role.role)
+            deriv_profname = re.sub('arn:aws:iam:.*/', '', role.role)
+
+            # check if write_aws_creds is true if so
+            # get the profile name and write out the file
+            if str(conf_dict['write_aws_creds']) == 'True':
+                # set the profile name
+                # Note if there are multiple roles, and 'default' is
+                # selected it will be overwritten multiple times and last role
+                # wins.
+                if conf_dict['cred_profile'].lower() == 'default':
+                    profile_name = 'default'
+                elif conf_dict['cred_profile'].lower() == 'role':
+                    profile_name = deriv_profname
+                else:
+                    profile_name = conf_dict['cred_profile']
+
+                # Write out the AWS Config file
+                print('writing role {} to {}'.format(role.role, self.AWS_CONFIG))
+                self._write_aws_creds(
+                    profile_name,
+                    aws_creds['AccessKeyId'],
+                    aws_creds['SecretAccessKey'],
+                    aws_creds['SessionToken']
+                )
+            else:
+                # Print out temporary AWS credentials.  Credentials are printed to stderr to simplify
+                # redirection for use in automated scripts
+                print("\nexport AWS_PROFILE=" + deriv_profname, file=sys.stderr)
+                print("export AWS_ACCESS_KEY_ID=" + aws_creds['AccessKeyId'], file=sys.stderr)
+                print("export AWS_SECRET_ACCESS_KEY=" + aws_creds['SecretAccessKey'], file=sys.stderr)
+                print("export AWS_SESSION_TOKEN=" + aws_creds['SessionToken'], file=sys.stderr)
 
         config.clean_up()
 

--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -72,8 +72,6 @@ class GimmeAWSCreds(object):
     FILE_ROOT = expanduser("~")
     AWS_CONFIG = FILE_ROOT + '/.aws/credentials'
 
-    def __init__(self):
-
     #  this is modified code from https://github.com/nimbusscale/okta_aws_login
     def _write_aws_creds(self, profile, access_key, secret_key, token):
         """ Writes the AWS STS token into the AWS credential file"""

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='gimme aws creds',
-    version='1.0.1',
+    version='1.0.2',
     install_requires=requirements,
     author='Ann Wallace',
     author_email='ann.wallace@nike.com',


### PR DESCRIPTION
The roles associated with a given Okta AWS application are not quite
accurate as they should specify the idp they expect to associate with.

This data can be extracted from the SAML assertion rather than just
trusting the list of roles returned by the OKTA API enumeration.

The issue is discussed further here -
https://github.com/Nike-Inc/gimme-aws-creds/issues/18

This pull request makes the following changes -

- Silly edit to gitignore to ignore Vim temp files

In bin/gimme-aws-creds
- base65/xml libraries for parsing saml assertion and extracting roles
- New function _enumerate_saml_roles which will extract all idp
  provider arn / role arn pairs from a saml assertion and return list
  of named tuples
- modified choose_role to enumerate and select from list of named
  tuples not from okta response
- modified behavior of credential gathering so that all roles can be
  enumerated.  this allows aws users with multiple roles across
  multiple accounts to have all their 1h credentials collected.

I believe all the original functionality is still intact, but
would definitely like another set of eyes to review and test!