### PR TITLE
Error Handling for App/Role Selection and documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A configuration wizard will prompt you to enter the necessary configuration para
 - write_aws_creds - y or n - If yes, the AWS credentials will be written to `~/.aws/credentials` otherwise it will be written to stdout.
 - cred_profile - If writing to the AWS cred file, this sets the name of the AWS credential profile.  The reserved word 'role' will use the name component of the role arn as the profile name.  i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [okta-1234-role] in the aws credentials file
 - aws_appname - This is optional. The Okta AWS App name, which has the role you want to assume.
-- aws_rolename - This is optional. The name of the role you want temporary AWS credentials for.  The reserved word 'all' can be used to get and store credentials for every role the user is permissioned for.
+- aws_rolename - This is optional. The ARN of the role you want temporary AWS credentials for.  The reserved word 'all' can be used to get and store credentials for every role the user is permissioned for.
 
 ## Usage
 

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -107,7 +107,7 @@ class Config(object):
                 write_aws_creds = Option to write creds to ~/.aws/credentials
                 cred_profile = Use DEFAULT or Role as the profile in ~/.aws/credentials
                 aws_appname = (optional) Okta AWS App Name
-                aws_rolename =  (optional) Okta Role Name
+                aws_rolename =  (optional) Okta Role ARN
         """
         config = configparser.ConfigParser()
         if self.configure:
@@ -266,10 +266,10 @@ class Config(object):
         return aws_appname
 
     def _get_aws_rolename(self, default_entry):
-        """ Get the AWS Role name"""
-        print("Enter the AWS role name you want credentials for."
+        """ Get the AWS Role ARN"""
+        print("Enter the ARN for the AWS role you want credentials for. 'ALL' will retrieve all roles."
               "\nThis is optional, you can select the role when you run the CLI.")
-        aws_rolename = self._get_user_input("AWS Role Name", default_entry)
+        aws_rolename = self._get_user_input("AWS Role ARN", default_entry)
         return aws_rolename
 
     def _get_conf_profile_name(self, default_entry):

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -67,7 +67,7 @@ class GimmeAWSCreds(object):
            write_aws_creds = Option to write creds to ~/.aws/credentials
            cred_profile = Use DEFAULT or Role as the profile in ~/.aws/credentials
            aws_appname = (optional) Okta AWS App Name
-           aws_rolename =  (optional) AWS Role Name. 'ALL' will retrieve all roles.
+           aws_rolename =  (optional) AWS Role ARN. 'ALL' will retrieve all roles.
     """
     FILE_ROOT = expanduser("~")
     AWS_CONFIG = FILE_ROOT + '/.aws/credentials'

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -258,9 +258,9 @@ class GimmeAWSCreds(object):
 
         return aws_info[int(selection)]
 
-    def _get_app(self, aws_appname, aws_info):
-        """ Compare the App name provided in the config file with the values
-        from the Okta API """
+    def _get_selected_app(self, aws_appname, aws_info):
+        """ select the application from the config file if it exists in the
+        results from Okta.  If not, present the user with a menu."""
 
         if aws_appname:
             for _, app in enumerate(aws_info):
@@ -271,10 +271,10 @@ class GimmeAWSCreds(object):
         # Present the user with a list of apps to choose from
         return self._choose_app(aws_info)
 
-    def _get_role(self, aws_rolename, aws_roles):
-        """ Compare the Role ARN provided in the config file with the values
-        from the SAML response """
-        
+    def _get_selected_role(self, aws_rolename, aws_roles):
+        """ select the role from the config file if it exists in the
+        results from Okta.  If not, present the user with a menu. """
+
         # 'all' is a special case - skip procesing
         if aws_rolename == 'all':
             return aws_rolename
@@ -394,10 +394,10 @@ class GimmeAWSCreds(object):
             print("Authentication Success! Calling Gimme-Creds Server...")
             aws_results = self._call_gimme_creds_server(okta, conf_dict['gimme_creds_server'])
 
-        aws_app = self._get_app(conf_dict.get('aws_appname'), aws_results)
+        aws_app = self._get_selected_app(conf_dict.get('aws_appname'), aws_results)
         saml_data = okta.get_saml_response(aws_app['links']['appLink'])
         roles = self._enumerate_saml_roles(saml_data['SAMLResponse'])
-        aws_role = self._get_role(conf_dict.get('aws_rolename'), roles)
+        aws_role = self._get_selected_role(conf_dict.get('aws_rolename'), roles)
 
         for i, role in enumerate(roles):
             # Skip irrelevant roles

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -51,3 +51,47 @@ class TestMain(unittest.TestCase):
         creds = GimmeAWSCreds()
         self.assertRaises(SystemExit, creds._choose_role, self.APP_INFO)
         self.assertRaises(SystemExit, creds._choose_app, self.AWS_INFO)
+
+    def test_get_app_from_config_0(self):
+        creds = GimmeAWSCreds()
+
+        selection = creds._get_app('test1', self.AWS_INFO)
+        self.assertEqual(selection, self.AWS_INFO[0])
+
+    def test_get_app_from_config_1(self):
+        creds = GimmeAWSCreds()
+
+        selection = creds._get_app('test2', self.AWS_INFO)
+        self.assertEqual(selection, self.AWS_INFO[1])
+
+    @patch('builtins.input', return_value='0')
+    def test_missing_app_from_config(self, mock):
+        creds = GimmeAWSCreds()
+
+        selection = creds._get_app('test3', self.AWS_INFO)
+        self.assertEqual(selection, self.AWS_INFO[0])
+
+    def test_get_role_from_config_0(self):
+        creds = GimmeAWSCreds()
+
+        selection = creds._get_role('test1', self.APP_INFO)
+        self.assertEqual(selection, 'test1')
+
+    def test_get_role_from_config_1(self):
+        creds = GimmeAWSCreds()
+
+        selection = creds._get_role('test2', self.APP_INFO)
+        self.assertEqual(selection, 'test2')
+
+    def test_get_role_all(self):
+        creds = GimmeAWSCreds()
+
+        selection = creds._get_role('all', self.APP_INFO)
+        self.assertEqual(selection, 'all')
+
+    @patch('builtins.input', return_value='0')
+    def test_missing_role_from_config(self, mock):
+        creds = GimmeAWSCreds()
+
+        selection = creds._get_role('test3', self.APP_INFO)
+        self.assertEqual(selection, 'test1')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -52,46 +52,46 @@ class TestMain(unittest.TestCase):
         self.assertRaises(SystemExit, creds._choose_role, self.APP_INFO)
         self.assertRaises(SystemExit, creds._choose_app, self.AWS_INFO)
 
-    def test_get_app_from_config_0(self):
+    def test_get_selected_app_from_config_0(self):
         creds = GimmeAWSCreds()
 
-        selection = creds._get_app('test1', self.AWS_INFO)
+        selection = creds._get_selected_app('test1', self.AWS_INFO)
         self.assertEqual(selection, self.AWS_INFO[0])
 
-    def test_get_app_from_config_1(self):
+    def test_get_selected_app_from_config_1(self):
         creds = GimmeAWSCreds()
 
-        selection = creds._get_app('test2', self.AWS_INFO)
+        selection = creds._get_selected_app('test2', self.AWS_INFO)
         self.assertEqual(selection, self.AWS_INFO[1])
 
     @patch('builtins.input', return_value='0')
     def test_missing_app_from_config(self, mock):
         creds = GimmeAWSCreds()
 
-        selection = creds._get_app('test3', self.AWS_INFO)
+        selection = creds._get_selected_app('test3', self.AWS_INFO)
         self.assertEqual(selection, self.AWS_INFO[0])
 
-    def test_get_role_from_config_0(self):
+    def test_get_selected_role_from_config_0(self):
         creds = GimmeAWSCreds()
 
-        selection = creds._get_role('test1', self.APP_INFO)
+        selection = creds._get_selected_role('test1', self.APP_INFO)
         self.assertEqual(selection, 'test1')
 
-    def test_get_role_from_config_1(self):
+    def test_get_selected_role_from_config_1(self):
         creds = GimmeAWSCreds()
 
-        selection = creds._get_role('test2', self.APP_INFO)
+        selection = creds._get_selected_role('test2', self.APP_INFO)
         self.assertEqual(selection, 'test2')
 
-    def test_get_role_all(self):
+    def test_get_selected_role_all(self):
         creds = GimmeAWSCreds()
 
-        selection = creds._get_role('all', self.APP_INFO)
+        selection = creds._get_selected_role('all', self.APP_INFO)
         self.assertEqual(selection, 'all')
 
     @patch('builtins.input', return_value='0')
     def test_missing_role_from_config(self, mock):
         creds = GimmeAWSCreds()
 
-        selection = creds._get_role('test3', self.APP_INFO)
+        selection = creds._get_selected_role('test3', self.APP_INFO)
         self.assertEqual(selection, 'test1')


### PR DESCRIPTION
Added error handling for an `aws_appname` or `aws_rolename` that is missing from the Okta response.  The user is warned of the missing value and can then select from the values that were present.

The recent changes to AWS role resolution (using the SAML response instead of the Okta API) changed the meaning of the `aws_rolename` from the friendly name of the role to the ARN.  I updated all the documentation and user prompts to reflect that.