### PR TITLE
Select AWS partition based on the SAML ACS endpoint

### DIFF
--- a/gimme_aws_creds/__init__.py
+++ b/gimme_aws_creds/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['config', 'okta', 'main']
-version = '1.0.4'
+version = '1.0.5'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -95,3 +95,26 @@ class TestMain(unittest.TestCase):
 
         selection = creds._get_selected_role('test3', self.APP_INFO)
         self.assertEqual(selection, 'test1')
+
+    def test_get_partition_aws(self):
+        creds = GimmeAWSCreds()
+
+        partition = creds._get_partition_from_saml_acs('https://signin.aws.amazon.com/saml')
+        self.assertEqual(partition, 'aws')
+
+    def test_get_partition_china(self):
+        creds = GimmeAWSCreds()
+
+        partition = creds._get_partition_from_saml_acs('https://signin.amazonaws.cn/saml')
+        self.assertEqual(partition, 'aws-cn')
+
+    def test_get_partition_govcloud(self):
+        creds = GimmeAWSCreds()
+
+        partition = creds._get_partition_from_saml_acs('https://signin.amazonaws-us-gov.com/saml')
+        self.assertEqual(partition, 'aws-us-gov')
+
+    def test_get_partition_unkown(self):
+        creds = GimmeAWSCreds()
+
+        self.assertRaises(SystemExit, creds._get_partition_from_saml_acs, 'https://signin.amazonaws-foo.com/saml')


### PR DESCRIPTION
Each AWS partition uses a different SAML AssertionConsumerService URL, so we can determine the partition based on that.

The Boto client can take a region as a parameter but not a partition, so I just select the first region for any partition other than the standard AWS.  China and GovCloud each only have one region right now, but when/if they add more we'll need to revisit that.  If you are connecting to an account in the standard AWS partition, I don't pass a region at all and use the default Boto behavior.