### PR TITLE
Performance improvement for internal Okta API handler 

### DIFF
--- a/gimme_aws_creds/__init__.py
+++ b/gimme_aws_creds/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['config', 'okta', 'main']
-version = '1.0.5'
+version = '1.0.6'


### PR DESCRIPTION
Since the IDP/role ARNs are now pulled from the SAML response, we can simplify the calls to the Okta APIs and just get the app link from the User API.  Eliminating the search against the Apps API yields a massive improvement in performance - around a 10x speed up in my tests.  