### PR TITLE
Use custom User-Agent for requests to Okta

### DIFF
--- a/gimme_aws_creds/__init__.py
+++ b/gimme_aws_creds/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['config', 'okta', 'main']
-version = '1.0.8'
+version = '1.0.9'

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -17,6 +17,7 @@ import uuid
 from codecs import decode
 from urllib.parse import parse_qs
 from urllib.parse import urlparse
+from . import version
 
 import keyring
 import requests
@@ -216,6 +217,7 @@ class OktaClient(object):
     def _get_headers():
         """sets the default headers"""
         headers = {
+            'User-Agent': "gimme-aws-creds {}".format(version),
             'Accept': 'application/json',
             'Content-Type': 'application/json'}
         return headers


### PR DESCRIPTION
Adding a custom User-Agent allows us to separate GAC requests out from other Okta logins and lets us see what versions are in use.