### PR TITLE
Avoid using API KEY by specifing an app url #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ With gimme-aws-creds all you need to know is your username, password, Okta url a
 Python 3
 
 ### Optional
-[Gimme-creds-lambda](https://github.com/Nike-Inc/gimme-aws-creds/tree/master/lambda) can be used as a proxy to the Okta APIs needed by gimme-aws-creds.  This removes the requirement of an Okta API key.  Gimme-aws-creds authneticates to gimme-creds-lambda using OpenID Connect and the lambda handles all interactions with the Okta APIs.  Alternately, you can set the `OKTA_API_KEY` environment variable and the `gimme_creds_server` configuration value to 'internal' to call the Okta APIs directly from gimme-aws-creds.
+[Gimme-creds-lambda](https://github.com/Nike-Inc/gimme-aws-creds/tree/master/lambda) can be used as a proxy to the Okta APIs needed by gimme-aws-creds.  This removes the requirement of an Okta API key.  Gimme-aws-creds authenticates to gimme-creds-lambda using OpenID Connect and the lambda handles all interactions with the Okta APIs.  Alternately, you can set the `OKTA_API_KEY` environment variable and the `gimme_creds_server` configuration value to 'internal' to call the Okta APIs directly from gimme-aws-creds.
 
 
 ## Installation
@@ -52,21 +52,25 @@ A configuration wizard will prompt you to enter the necessary configuration para
 - okta_org_url - This is your Okta organization url, which is typically something like `https://companyname.okta.com`.
 - okta_auth_server - [Okta API Authorization Server](https://help.okta.com/en/prev/Content/Topics/Security/API_Access.htm) used for OpenID Connect authentication for gimme-creds-lambda
 - client_id - OAuth client ID for gimme-creds-lambda
-- gimme_creds_server - URL for gimme-creds-lambda or 'internal' for direct interaction with the Okta APIs (`OKTA_API_KEY` environment variable required)
+- gimme_creds_server 
+	- URL for gimme-creds-lambda 
+	- 'internal' for direct interaction with the Okta APIs (`OKTA_API_KEY` environment variable required)
+	- 'appurl' to set an aws application link url. This setting removes the need of an OKTA API key.
 - write_aws_creds - y or n - If yes, the AWS credentials will be written to `~/.aws/credentials` otherwise it will be written to stdout.
 - cred_profile - If writing to the AWS cred file, this sets the name of the AWS credential profile.  The reserved word 'role' will use the name component of the role arn as the profile name.  i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [okta-1234-role] in the aws credentials file
 - aws_appname - This is optional. The Okta AWS App name, which has the role you want to assume.
 - aws_rolename - This is optional. The ARN of the role you want temporary AWS credentials for.  The reserved word 'all' can be used to get and store credentials for every role the user is permissioned for.
+- app_url - If using 'appurl' setting for gimme_creds_server, this sets the url to the aws application configured in Okta. It is typically something like https://something.okta[preview].com/home/amazon_aws/app_instance_id/something
 
 ## Usage
 
-**If you are not using gimme-creds-lambda, make sure you the OKTA_API_KEY environment variable.**
+**If you are not using gimme-creds-lambda nor using appurl settings, make sure you set the OKTA_API_KEY environment variable.**
 
 After running --configure, just run gimme-aws-creds. You will be prompted for the necessary information.
 
 ```bash
 $ ./gimme-aws-creds
-Email address: user@domain.com
+Username: user@domain.com
 Password for user@domain.com:
 Authentication Success! Calling Gimme-Creds Server...
 Pick an app:

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -215,7 +215,7 @@ class Config(object):
 		
     def _get_applink_entry(self, default_entry):
         """ Get and validate app_link """
-        print("Enter the application link")
+        print("Enter the application link. This is https://something.okta[preview].com/home/amazon_aws/<app_id>/something")
 
         app_link = self._get_user_input("Application link", default_entry)
         self._app_link = app_link

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -113,7 +113,7 @@ class GimmeAWSCreds(object):
         # Normalize pieces of string; order may vary per AWS sample
         result = []
         for role_pair in role_pairs:
-            idp, role, friendly_account_name, friendly_role_name = None, None, None, None
+            idp, role = None, None
             for field in role_pair.split(','):
                 if 'saml-provider' in field:
                     idp = field
@@ -294,21 +294,6 @@ class GimmeAWSCreds(object):
         # Present the user with a list of roles to choose from
         return self._choose_role(aws_roles)
 
-    @staticmethod
-    def _display_role(roles):
-        """ gets a list of available roles and
-        asks the user to select the role they want to assume
-        """
-        # Gather the roles available to the user.
-        role_strs = []
-        for i, role in enumerate(roles):
-            if not role:
-                continue
-            role_strs.append('[{}] {}'.format(i, role.role))
-
-        return role_strs
-
-
     def _choose_role(self, roles):
         """ gets a list of available roles and
         asks the user to select the role they want to assume
@@ -317,7 +302,11 @@ class GimmeAWSCreds(object):
             return None
 
         # Gather the roles available to the user.
-        role_strs = self._display_role(roles)
+        role_strs = []
+        for i, role in enumerate(roles):
+            if not role:
+                continue
+            role_strs.append('[{}] {}'.format(i, role.role))
 
         if role_strs:
             print("Pick a role:")

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -30,11 +30,8 @@ from okta.framework.OktaError import OktaError
 # local imports
 from gimme_aws_creds.config import Config
 from gimme_aws_creds.okta import OktaClient
-from gimme_aws_creds.aws import AwsClient
-import gimme_aws_creds.gdef as gdef
 
-
-#RoleSet = namedtuple('RoleSet', 'idp, role, friendly_account_name, friendly_role_name')
+RoleSet = namedtuple('RoleSet', 'idp, role')
 
 
 class GimmeAWSCreds(object):
@@ -126,7 +123,7 @@ class GimmeAWSCreds(object):
                 print('Parsing error on {}'.format(role_pair))
                 exit()
             else:
-                result.append(gdef.RoleSet(idp=idp, role=role))
+                result.append(RoleSet(idp=idp, role=role))
 
         return result
 
@@ -320,8 +317,7 @@ class GimmeAWSCreds(object):
             return None
 
         # Gather the roles available to the user.
-        # role_strs = self._display_role(roles)
-        role_strs = AwsClient._display_role(roles)
+        role_strs = self._display_role(roles)
 
         if role_strs:
             print("Pick a role:")
@@ -378,7 +374,6 @@ class GimmeAWSCreds(object):
             exit(1)
 
         okta = OktaClient(conf_dict['okta_org_url'], config.verify_ssl_certs)
-        aws_signin = AwsClient(config.verify_ssl_certs)
 
         if config.username is not None:
             okta.set_username(config.username)
@@ -444,9 +439,7 @@ class GimmeAWSCreds(object):
 
         aws_app = self._get_selected_app(conf_dict.get('aws_appname'), aws_results)
         saml_data = okta.get_saml_response(aws_app['links']['appLink'])
-#        roles = self._enumerate_saml_roles(saml_data['SAMLResponse'])
-        aws_signin_page = aws_signin.get_signinpage(saml_data['SAMLResponse'])
-        roles = aws_signin._enumerate_saml_roles(aws_signin_page, saml_data['SAMLResponse'])
+        roles = self._enumerate_saml_roles(saml_data['SAMLResponse'])
         aws_role = self._get_selected_role(conf_dict.get('aws_rolename'), roles)
         aws_partition = self._get_partition_from_saml_acs(saml_data['TargetUrl'])
 

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -504,13 +504,8 @@ class OktaClient(object):
             username = self._username
         # Otherwise just ask the user
         else:
-            username = input("Email address: ")
+            username = input("Username: ")
             self._username = username
-
-        # The Okta username must be an email address
-        if not re.match("[^@]+@[^@]+\.[^@]+", username):
-            print("Okta username must be an email address.")
-            exit(1)
 
         # noinspection PyBroadException
         password = None
@@ -521,8 +516,8 @@ class OktaClient(object):
                 print("Using password from keyring for {}".format(username))
             except RuntimeError:
                 print("Unable to get password from keyring.")
-
         if not password:
+            print('Prompting Password ...')
             # Set prompt to include the user name, since username could be set
             # via OKTA_USERNAME env and user might not remember.
             for x in range(0, 5):

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -517,7 +517,6 @@ class OktaClient(object):
             except RuntimeError:
                 print("Unable to get password from keyring.")
         if not password:
-            print('Prompting Password ...')
             # Set prompt to include the user name, since username could be set
             # via OKTA_USERNAME env and user might not remember.
             for x in range(0, 5):

--- a/tests/test_okta_client.py
+++ b/tests/test_okta_client.py
@@ -230,12 +230,12 @@ class TestOktaClient(unittest.TestCase):
         result = self.client._get_username_password_creds()
         assert_equals(result, {'username': 'ann@example.com', 'password': '1234qwert' })
 
-    @patch('getpass.getpass', return_value='1234qwert')
-    @patch('builtins.input', return_value='ann')
-    def test_bad_username(self, mock_pass, mock_input):
-        """Test that initial authentication works with Okta"""
-        with self.assertRaises(SystemExit):
-            self.client._get_username_password_creds()
+#    @patch('getpass.getpass', return_value='1234qwert')
+#    @patch('builtins.input', return_value='ann')
+#    def test_bad_username(self, mock_pass, mock_input):
+#        """Test that initial authentication works with Okta"""
+#        with self.assertRaises(SystemExit):
+#            self.client._get_username_password_creds()
 
     @patch('getpass.getpass', return_value='')
     @patch('builtins.input', return_value='ann@example.com')


### PR DESCRIPTION
Hi,
If you use MFA for AuthN, awsprocesscreds still have some problem with handling MFA properly.
So here are the small modifications to handle app url without the need of using of an OKTA API KEY

- adding the option to use an application url instead of using API KEY.
- defaulting to appurl in configuration
- remove the email constraint in login (not mandatory in Okta)
- this change do not remove the existing options that are using OKTA API KEY (to remove in next step)
