### PR TITLE
Store Preferred MFA Device Type in Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ A configuration wizard will prompt you to enter the necessary configuration para
 - okta_org_url - This is your Okta organization url, which is typically something like `https://companyname.okta.com`.
 - okta_auth_server - [Okta API Authorization Server](https://help.okta.com/en/prev/Content/Topics/Security/API_Access.htm) used for OpenID Connect authentication for gimme-creds-lambda
 - client_id - OAuth client ID for gimme-creds-lambda
-- gimme_creds_server 
-	- URL for gimme-creds-lambda 
+- gimme_creds_server
+	- URL for gimme-creds-lambda
 	- 'internal' for direct interaction with the Okta APIs (`OKTA_API_KEY` environment variable required)
 	- 'appurl' to set an aws application link url. This setting removes the need of an OKTA API key.
 - write_aws_creds - y or n - If yes, the AWS credentials will be written to `~/.aws/credentials` otherwise it will be written to stdout.
@@ -61,6 +61,11 @@ A configuration wizard will prompt you to enter the necessary configuration para
 - aws_appname - This is optional. The Okta AWS App name, which has the role you want to assume.
 - aws_rolename - This is optional. The ARN of the role you want temporary AWS credentials for.  The reserved word 'all' can be used to get and store credentials for every role the user is permissioned for.
 - app_url - If using 'appurl' setting for gimme_creds_server, this sets the url to the aws application configured in Okta. It is typically something like https://something.okta[preview].com/home/amazon_aws/app_instance_id/something
+- preferred_mfa_type - automatically select a particular  device when prompted for MFA:
+  - push - Okta Verify App push
+  - token:software:totp - OTP using the Okta Verify App
+  - call - OTP via Voice call 
+  - sms - OTP via SMS message
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ A configuration wizard will prompt you to enter the necessary configuration para
 - aws_appname - This is optional. The Okta AWS App name, which has the role you want to assume.
 - aws_rolename - This is optional. The ARN of the role you want temporary AWS credentials for.  The reserved word 'all' can be used to get and store credentials for every role the user is permissioned for.
 - app_url - If using 'appurl' setting for gimme_creds_server, this sets the url to the aws application configured in Okta. It is typically something like https://something.okta[preview].com/home/amazon_aws/app_instance_id/something
+- okta_username - use this username to authenticate
 - preferred_mfa_type - automatically select a particular  device when prompted for MFA:
   - push - Okta Verify App push
   - token:software:totp - OTP using the Okta Verify App
-  - call - OTP via Voice call 
+  - call - OTP via Voice call
   - sms - OTP via SMS message
 
 ## Usage

--- a/gimme_aws_creds/__init__.py
+++ b/gimme_aws_creds/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['config', 'okta', 'main']
-version = '1.0.11'
+version = '1.0.12'

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -115,6 +115,7 @@ class Config(object):
                 aws_appname = (optional) Okta AWS App Name
                 aws_rolename =  (optional) Okta Role ARN
                 okta_username = Okta username
+                preferred_mfa_type = Select this MFA device type automatically
         """
         config = configparser.ConfigParser()
         if self.configure:
@@ -130,7 +131,8 @@ class Config(object):
             'write_aws_creds': '',
             'cred_profile': 'role',
             'okta_username': '',
-			'app_url': ''
+            'preferred_mfa_type': '',
+			      'app_url': ''
         }
 
         # See if a config file already exists.
@@ -160,6 +162,7 @@ class Config(object):
             config_dict['aws_appname'] = self._get_aws_appname(defaults['aws_appname'])
         config_dict['aws_rolename'] = self._get_aws_rolename(defaults['aws_rolename'])
         config_dict['okta_username'] = self._get_okta_username(defaults['okta_username'])
+        config_dict['preferred_mfa_type'] = self._get_preferred_mfa_type(defaults['preferred_mfa_type'])
 
         # If write_aws_creds is True get the profile name
         if config_dict['write_aws_creds'] is True:
@@ -213,7 +216,7 @@ class Config(object):
         self._client_id = client_id
 
         return client_id
-		
+
     def _get_appurl_entry(self, default_entry):
         """ Get and validate app_url """
         print("Enter the application link. This is https://something.okta[preview].com/home/amazon_aws/<app_id>/something")
@@ -231,7 +234,7 @@ class Config(object):
 
         self._app_url = app_url
 
-        return app_url		
+        return app_url
 
     def _get_gimme_creds_server_entry(self, default_entry):
         """ Get gimme_creds_server """
@@ -317,10 +320,18 @@ class Config(object):
 
     def _get_okta_username(self, default_entry):
         """Get and validate okta username. [Optional]"""
-        print("If you'd like to set your okta username in the config file, specify the username\n."
+        print("If you'd like to set your okta username in the config file, specify the username.\n"
               "This is optional.")
         okta_username = self._get_user_input(
             "Okta User Name", default_entry)
+        return okta_username
+
+    def _get_preferred_mfa_type(self, default_entry):
+        """Get the user's preferred MFA device [Optional]"""
+        print("If you'd like to set a preferred device type to use for MFA, enter it here.\n"
+              "This is optional. valid devices types:[sms, call, push, token, token:software:totp]")
+        okta_username = self._get_user_input(
+            "Preferred MFA Device Type", default_entry)
         return okta_username
 
     @staticmethod

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -240,7 +240,7 @@ class GimmeAWSCreds(object):
             return None
 
         if len(aws_info) == 1:
-            return aws_info[0];	# auto select when only 1 choice 
+            return aws_info[0];	# auto select when only 1 choice
 
         app_strs = []
         for i, app in enumerate(aws_info):
@@ -265,7 +265,7 @@ class GimmeAWSCreds(object):
     def _get_selected_app(self, aws_appname, aws_info):
         """ select the application from the config file if it exists in the
         results from Okta.  If not, present the user with a menu."""
-		
+
         if aws_appname:
             for _, app in enumerate(aws_info):
                 if app["name"] == aws_appname:
@@ -274,7 +274,7 @@ class GimmeAWSCreds(object):
                     # auto select this app
                     return app
             print("ERROR: AWS account [{}] not found!".format(aws_appname))
-			
+
         # Present the user with a list of apps to choose from
         return self._choose_app(aws_info)
 
@@ -371,6 +371,9 @@ class GimmeAWSCreds(object):
             if conf_dict.get('okta_username'):
                 okta.set_username(conf_dict['okta_username'])
 
+        if conf_dict.get('preferred_mfa_type'):
+            okta.set_preferred_mfa_type(conf_dict['preferred_mfa_type'])
+
         # Call the Okta APIs and proces data locally
         if conf_dict.get('gimme_creds_server') == 'internal':
             # Okta API key is required when calling Okta APIs internally
@@ -404,7 +407,7 @@ class GimmeAWSCreds(object):
             newAppEntry['links'] = {}
             newAppEntry['links']['appLink'] = config.app_url
             aws_results.append(newAppEntry)
-			
+
         # Use the gimme_creds_lambda service
         else:
             if not conf_dict.get('client_id'):


### PR DESCRIPTION
Added a new config value (`preferred_mfa_type`) which will auto push/sms/call you instead of choosing a factor type from a list. #53 