### PR TITLE
MFA command line option, better MFA error handling

### DIFF
--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -37,6 +37,7 @@ class Config(object):
         self.verify_ssl_certs = True
         self.app_url = None
         self.resolve = False
+        self.mfa_code = None
         self.aws_default_duration = 3600
 
         if os.environ.get("OKTA_USERNAME") is not None:
@@ -76,6 +77,11 @@ class Config(object):
             help='Allow connections to SSL sites without cert verification.'
         )
         parser.add_argument(
+            '--mfa-code',
+            help="The MFA verification code to be used with SMS or TOTP authentication methods. "
+            "If not provided you will be prompted to enter an MFA verification code."
+        )
+        parser.add_argument(
             '--version', action='version',
             version='%(prog)s {}'.format(version),
             help='gimme-aws-creds version')
@@ -89,6 +95,8 @@ class Config(object):
             self.verify_ssl_certs = True
         if args.username is not None:
             self.username = args.username
+        if args.mfa_code is not None:
+            self.mfa_code = args.mfa_code
         if args.resolve is True:
             self.resolve = True
         self.conf_profile = args.profile or 'DEFAULT'

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -49,22 +49,24 @@ class GimmeAWSCreds(object):
        --configure was ran.
 
        Usage:
-         -h, --help     show this help message and exit
-         --username USERNAME, -u USERNAME
-                        The username to use when logging into Okta. The
-                        username can also be set via the OKTA_USERNAME env
-                        variable. If not provided you will be prompted to
-                        enter a username.
-         -k, --insecure Allow connections to SSL sites without cert verification
-         -c, --configure
-                        If set, will prompt user for configuration
-                        parameters and then exit.
-         --profile PROFILE, -p PROFILE
-                        If set, the specified configuration profile will
-                        be used instead of the default profile.
-         -r, --resolve
-                        Default does not resolve account alias
-                        If set, account alias will be resolved. 
+          -h, --help            show this help message and exit
+          --username USERNAME, -u USERNAME
+                                The username to use when logging into Okta. The
+                                username can also be set via the OKTA_USERNAME env
+                                variable. If not provided you will be prompted to
+                                enter a username.
+          --configure, -c       If set, will prompt user for configuration parameters
+                                and then exit.
+          --profile PROFILE, -p PROFILE
+                                If set, the specified configuration profile will be
+                                used instead of the default.
+          --resolve, -r         If set, perfom alias resolution.
+          --insecure, -k        Allow connections to SSL sites without cert
+                                verification.
+          --mfa-code MFA_CODE   The MFA verification code to be used with SMS or TOTP
+                                authentication methods. If not provided you will be
+                                prompted to enter an MFA verification code.
+          --version             gimme-aws-creds version
 
         Config Options:
            okta_org_url = Okta URL
@@ -355,6 +357,9 @@ class GimmeAWSCreds(object):
         if conf_dict.get('preferred_mfa_type'):
             okta.set_preferred_mfa_type(conf_dict['preferred_mfa_type'])
 
+        if config.mfa_code is not None:
+            okta.set_mfa_code(config.mfa_code)
+
         # AWS Default session duration ....
         if conf_dict.get('aws_default_duration'):
             config.aws_default_duration = int(conf_dict['aws_default_duration'])
@@ -435,7 +440,7 @@ class GimmeAWSCreds(object):
                 if ex.response['Error']['Message'] == 'The requested DurationSeconds exceeds the MaxSessionDuration set for this role.':
                     print("The requested session duration was too long for this role.  Falling back to 1 hour.")
                     aws_creds = self._get_sts_creds(aws_partition, saml_data['SAMLResponse'], role.idp, role.role, 3600)
-            
+
             deriv_profname = re.sub('arn:aws:iam:.*/', '', role.role)
 
             # check if write_aws_creds is true if so

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,10 +22,10 @@ class TestConfig(unittest.TestCase):
         self.config.clean_up()
 
     @patch('argparse.ArgumentParser.parse_args',
-           return_value=argparse.Namespace(username='ann', configure=False, profile=None, insecure=False, resolve=None))
+           return_value=argparse.Namespace(username='ann', configure=False, profile=None, insecure=False, resolve=None, mfa_code=None))
     def test_get_args_username(self, mock_arg):
         """Test to make sure username gets returned"""
         self.config.get_args()
         assert_equals(self.config.username, 'ann')
 
-    
+


### PR DESCRIPTION
Updated the handling of MFA failures to prevent exceptions and print useful error messages instead.

Added ability to specify a MFA code (for TOTP and SMS) on the command line with a new --mfa-code parameter.  If the parameter isn't provided, the existing prompt is still used to query the user.

Cosmetic update to the main.py comment to include the current command line parameters.

This allows the gimme-aws-creds CLI tool to be used by other scripts that won't necessarily be able to prompt the user for MFA code input.  With other CLI tools, like oathtool, MFA can be handled in an scriptable/automated manner on trusted devices that can generate MFA codes automatically immediately prior to calling gimme-aws-creds.