### PR TITLE
Issue 72: bugfix related to aws-cn creds

### DIFF
--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -447,7 +447,11 @@ class GimmeAWSCreds(object):
                     print("The requested session duration was too long for this role.  Falling back to 1 hour.")
                     aws_creds = self._get_sts_creds(aws_partition, saml_data['SAMLResponse'], role.idp, role.role, 3600)
 
-            deriv_profname = re.sub('arn:aws:iam:.*/', '', role.role)
+            #condition to account for 'arn:aws-cn:...'
+            if role.role[:10] == 'arn:aws-cn':
+                deriv_profname = re.sub('arn:aws-cn:iam:.*/', '', role.role)
+            else:
+                deriv_profname = re.sub('arn:aws:iam:.*/', '', role.role)
 
             # check if write_aws_creds is true if so
             # get the profile name and write out the file


### PR DESCRIPTION
Currently if you grab creds for any of the aws china accounts using a profile you've configured, the creds get stored in your .aws/credentials file as an arn instead of just the profile name. 

This is because the name is set by removing the first portion of the role but is only hardcoded for "arn:aws:…" where aws china roles look like "arn:aws-cn:...".

I added a condition to check if the role is for an aws china account to fix this issue. 
