### PR TITLE
Moved input prompts from stdout to stderr

### DIFF
--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -586,7 +586,7 @@ class OktaClient(object):
 
             if self.KEYRING_ENABLED:
                 # If the OS supports a keyring, offer to save the password
-                print("Do you want to sace this password in the keyring? (y/n) ", end='', file=sys.stderr)
+                print("Do you want to save this password in the keyring? (y/n) ", end='', file=sys.stderr)
                 if input() == 'y':
                     try:
                         keyring.set_password(self.KEYRING_SERVICE, username, password)


### PR DESCRIPTION
Moved input prompts in okta.py from stdout to stderr so they wouldn't be obscured when redirecting run output to a file.  See commit comments for details.