### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+CHANGELOG.md
+CONTRIBUTING.md
+Makefile
+README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+sudo: required
+services:
+- docker
 python:
 - '3.5'
 - '3.6'
@@ -6,7 +9,7 @@ install:
 - pip install -r requirements_dev.txt
 - python3 setup.py install
 script:
-- nosetests --verbosity=2 tests/
+- make test
 deploy:
   provider: pypi
   distributions: "sdist bdist_wheel"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,5 @@ COPY . .
 RUN apk --update add gcc musl-dev libffi-dev openssl-dev \
     && python setup.py install \
     && apk del --purge gcc musl-dev libffi-dev openssl-dev
+
+ENTRYPOINT ['/usr/local/bin/gimme-aws-creds']

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.7-alpine
+
+WORKDIR /opt/gimme-aws-creds
+
+COPY . .
+
+RUN apk --update add gcc musl-dev libffi-dev openssl-dev \
+    && python setup.py install \
+    && apk del --purge gcc musl-dev libffi-dev openssl-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN apk --update add gcc musl-dev libffi-dev openssl-dev \
     && python setup.py install \
     && apk del --purge gcc musl-dev libffi-dev openssl-dev
 
-ENTRYPOINT ['/usr/local/bin/gimme-aws-creds']
+ENTRYPOINT ["/usr/local/bin/gimme-aws-creds"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 init:
 	pip3 install -r requirements_dev.txt
 
-test:
+docker-build:
+	docker build -t gimme-aws-creds .
+
+test: docker-build
 	nosetests -vv tests

--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ Install the gimme-aws-creds package if you have already cloned the source:
 python3 setup.py install
 ```
 
+__OR__
+
+Build the docker image locally:
+```bash
+docker build -t gimme-aws-creds .
+```
+To make it easier you can also create an alias for the gimme-aws-creds command with docker:
+```bash
+# make sure you have the "~/.okta_aws_login_config" locally first!
+touch ~/.okta_aws_login_config && \
+alias gimme-aws-creds="docker run -it --rm \
+  -v ~/.aws/credentials:/root/.aws/credentials \
+  -v ~/.okta_aws_login_config:/root/.okta_aws_login_config \
+  gimme-aws-creds"
+```
+With this config, you will be able to run further commands seamlessly!
+
 ## Configuration
 
 To set-up the configuration run:
@@ -132,7 +149,7 @@ $ nosetests --verbosity=2 tests/
 This project is maintained by [Ann Wallace](https://github.com/anners), [Eric Pierce](https://github.com/epierce), and [Justin Wiley](https://github.com/sectornine50).
 
 ## Thanks and Credit
-I came across [okta_aws_login](https://github.com/nimbusscale/okta_aws_login) written by Joe Keegan, when I was searching for a CLI tool that generates AWS tokens via Okta. Unfortunately it hasn't been updated since 2015 and didn't seem to work with the current Okta version. But there was still some great code I was able to reuse under the MIT license for gimme-aws-creds. I have noted in the comments where I used his code, to make sure he receives proper credit.  
+I came across [okta_aws_login](https://github.com/nimbusscale/okta_aws_login) written by Joe Keegan, when I was searching for a CLI tool that generates AWS tokens via Okta. Unfortunately it hasn't been updated since 2015 and didn't seem to work with the current Okta version. But there was still some great code I was able to reuse under the MIT license for gimme-aws-creds. I have noted in the comments where I used his code, to make sure he receives proper credit.
 
 ## Etc.
 


### PR DESCRIPTION
This PR adds a basic Dockerfile. The built container can be used to run the command `gimme-aws-creds` without having project built in your system wide python installation.

The TravisCI integration was enhanced to use the existing Makefile and build the container together with the unittests.

The Makefile should be used in the future to push the image to Dockerhub.

