### PR TITLE
Ability to change the configuration fle path

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can also set up different Okta configuration profiles, this useful if you ha
 gimme-aws-creds --configure --profile profileName
 ```
 
-A configuration wizard will prompt you to enter the necessary configuration parameters for the tool to run, the only one that is required is the `okta_org_url`. The configuration file is written to `~/.okta_aws_login_config`.
+A configuration wizard will prompt you to enter the necessary configuration parameters for the tool to run, the only one that is required is the `okta_org_url`. The configuration file is written to `~/.okta_aws_login_config`, but you can change the location with the environment variable `OKTA_CONFIG`.
 
 - conf_profile - This sets the Okta configuration profile name, the default is DEFAULT.
 - okta_org_url - This is your Okta organization url, which is typically something like `https://companyname.okta.com`.

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -27,7 +27,7 @@ class Config(object):
        under the MIT license.
     """
     FILE_ROOT = expanduser("~")
-    OKTA_CONFIG = FILE_ROOT + '/.okta_aws_login_config'
+    OKTA_CONFIG = os.environ.get("OKTA_CONFIG", os.path.join(FILE_ROOT, '.okta_aws_login_config'))
 
     def __init__(self):
         self.configure = False


### PR DESCRIPTION
The default cofiguration path can be overriden using the environment
variable OKTA_CONFIG.