### PR TITLE
Allow custom AWS credentials file location

### DIFF
--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -80,7 +80,7 @@ class GimmeAWSCreds(object):
            okta_username = (optional) Okta User Name
     """
     FILE_ROOT = expanduser("~")
-    AWS_CONFIG = FILE_ROOT + '/.aws/credentials'
+    AWS_CONFIG = os.environ.get('AWS_SHARED_CREDENTIALS_FILE', os.path.join(FILE_ROOT, '.aws/credentials'))
     resolver = DefaultResolver()
 
     #  this is modified code from https://github.com/nimbusscale/okta_aws_login


### PR DESCRIPTION
Honor AWS_SHARED_CREDENTIALS_FILE environment variable if defined by the user to change the credentials file location.

+info:
https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html