### PR TITLE
Use stderr for picking AWS role

### DIFF
--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -313,7 +313,8 @@ class GimmeAWSCreds(object):
         selection = None
         for _ in range(0, max_retries):
             try:
-                selection = int(input("Selection: "))
+                print("Selection: ", end="", file=sys.stderr)
+                selection = int(input())
                 break
             except ValueError:
                 print('Invalid selection, must be an integer value.', file=sys.stderr)


### PR DESCRIPTION
Currently, when `gimme-aws-creds` prompts for what AWS role the user wants to select, it outputs the prompt on stdout instead of stderr.  This causes piping or shell `eval`ing to receive the prompt and can break scripting.  This PR fixes that, outputting the prompt on stderr instead, similar to the work that was done in 965d2f7.