### PR TITLE
correctly compare roles

### DIFF
--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -447,7 +447,7 @@ class GimmeAWSCreds(object):
 
         for _, role in enumerate(roles):
             # Skip irrelevant roles
-            if aws_role != 'all' and aws_role not in role.role:
+            if aws_role != 'all' and aws_role != role.role:
                 continue
 
             try:


### PR DESCRIPTION
Without this change, roles that share a basename - for example, `TEAM-ROLE` and `TEAM-ROLE-PRODUCTION`, will improperly select `TEAM-ROLE-PRODUCTION` when attempting to choose `TEAM-ROLE`