### PR TITLE
Quick fix sourcing the config file prior to creating new section

### DIFF
--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -208,6 +208,7 @@ class Config(object):
 
     def write_config_file(self, config_dict):
         config = configparser.ConfigParser()
+        config.read(self.OKTA_CONFIG)
         config[self.conf_profile] = config_dict
 
         # write out the conf file


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This fix will remediate the issues when trying to use `gimme-aws-creds --config -p profile_name` overwriting the file completely.

## Description
<!--- Describe your changes in detail -->
The only thing changed was reading the config file prior to writing

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Here is a link to the issue #77 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally from a `virtualenv`
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
