### PR TITLE
Switching to Travis jobs syntax.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,34 @@
 language: python
 sudo: required
+
 services:
-- docker
+  - docker
+  
 python:
-- '3.5'
-- '3.6'
+  - '3.5'
+  - '3.6'
+  
 install:
-- pip install -r requirements_dev.txt
-- python3 setup.py install
-script:
-- make test
-deploy:
-  provider: pypi
-  distributions: "sdist bdist_wheel"
-  user:
-    secure: 6y/5ZnnYsoLYn1QZ5ZoFrOBVphluunrEZUcNdNhFWj0TJwgX/s2W+l4lB2N7EtANKbiGjQfWFa1vBBZ//lWNnJtDnBstX9Lu/mHHXBe+2i6/eMm+C5tK3zifRKxawVHP3nUcC5mn/ITTCU3FNkT4RVPWZQbV8zoPMdsvk6dO/oOTZta+Ttt666iI52vGYZ3r2qfRSTi7GBCBBE2rwndRdRpzGtR3cGso02kpmEVM6FQxF8MOTTCPHKSAp6baKqHM0I7cJVz7X8kcZ5+0emJrCNCQAX1WJgoIU6gUIwMt2+3xW31C6r8a/rujvMVKstr+rwNJ3nD0MqFyN6Obha7YLFlsKqzuCNJKcx5v+2zpZMgZaovYgCQVLuwzRjPuQ7a2hnwYrF2HOIlrgtMlEJiFLUfDne6E5FykpOUkooVoyw+HrXLfivu+3vq0UbsAc5rL9a1iZCJFn2MxDV3G9MbPQIQkHzP5mayfVjf2kr07Be6ynjS0YffYcOFcJubB680MrnOMX4Qc9akCI1HTlN73K4G0alqI5PskfQ12s2Djbdl3v67v7XUQDzTC/TsFOGzfNoV4DC95snsVzmiEW1TTSLW7N7LBCNaoLdeEu5LyAPOchQhzOEQod+9FGGf39+lB2+ezEM01eF5liU+cGBWRXj8j5iRYprLkab461aGNjco=
-  password:
-    secure: QWeG6Z6RxKJspka3742P8RU7+mwrZjm9WPE7Zqcqi/hTXS+7UHBXpVoz0k1kYXezCjf4tbX9EJ542ncI3iby3eFbSh4uDphuDlvcUeL9nb+y36FD7/soKVL+m+t2q027zUv0hQVoA4Xe63urp64OCASvedmKTTWBWYjzQEhXJx8pIlfnXKppkNWFFTQp7uLMguQlBunk7h3rHHP1cigy0Es0OUXd9l7f/8ZrlFi/tmPZ1P0488uCAEsFM83SUHggk0edQvTxMFYNTZ07+A8jdJSh0okvIbzy6PBrN2DmIMoVrwro9d5i/Ek59BULwjlV5bXffcRqsiM2jcl4ueA6t60u0r8JX4onMTVEOQxX/51q2yZX+tNo186eHJUIlCE006R+Sj/J5oG6ErXuJqypcthZkMytTRprRNRx8ALcKVnnyqUQR8GbDyfKtzWqqZ8wutwmWyUqlFDmHei0l9MHbPzu2uiyzH7xN0YGNCcWqdHzcmTL1nVwATB7++cSdO22sfvATQGTPUljeS5/ed+d0WW2U7eL8u7vCJVjciC89R9YHHFUkBIeZz8MCr7GHb/zdLsm6DeiT0dAHQvYuYc6Q8nlrBoGbUxqWN2jA5BbLQdZTr+9q/LTSBIUsRC+6gEiuY/MnrlJ8lztL4NWD7lMCQZG5OSVdkpscW7qA3IHTLk=
-  on:
-    tags: true
+  - pip install -r requirements_dev.txt
+  - python3 setup.py install
+  
+jobs:
+  include:
+    - stage: "Tests"
+      name: "Test Python 3.5"
+      python: '3.5'
+      script: make test
+    - name: "Test Python 3.6"
+      python: '3.6'
+      script: make test
+      
+    - stage: deploy
+      name: "Deploy to PyPI"
+      if: (tag =~ ^v) AND (branch = master)
+      python: '3.6'
+      provider: pypi
+      distributions: "sdist bdist_wheel"
+      user:
+        secure: 6y/5ZnnYsoLYn1QZ5ZoFrOBVphluunrEZUcNdNhFWj0TJwgX/s2W+l4lB2N7EtANKbiGjQfWFa1vBBZ//lWNnJtDnBstX9Lu/mHHXBe+2i6/eMm+C5tK3zifRKxawVHP3nUcC5mn/ITTCU3FNkT4RVPWZQbV8zoPMdsvk6dO/oOTZta+Ttt666iI52vGYZ3r2qfRSTi7GBCBBE2rwndRdRpzGtR3cGso02kpmEVM6FQxF8MOTTCPHKSAp6baKqHM0I7cJVz7X8kcZ5+0emJrCNCQAX1WJgoIU6gUIwMt2+3xW31C6r8a/rujvMVKstr+rwNJ3nD0MqFyN6Obha7YLFlsKqzuCNJKcx5v+2zpZMgZaovYgCQVLuwzRjPuQ7a2hnwYrF2HOIlrgtMlEJiFLUfDne6E5FykpOUkooVoyw+HrXLfivu+3vq0UbsAc5rL9a1iZCJFn2MxDV3G9MbPQIQkHzP5mayfVjf2kr07Be6ynjS0YffYcOFcJubB680MrnOMX4Qc9akCI1HTlN73K4G0alqI5PskfQ12s2Djbdl3v67v7XUQDzTC/TsFOGzfNoV4DC95snsVzmiEW1TTSLW7N7LBCNaoLdeEu5LyAPOchQhzOEQod+9FGGf39+lB2+ezEM01eF5liU+cGBWRXj8j5iRYprLkab461aGNjco=
+      password:
+        secure: QWeG6Z6RxKJspka3742P8RU7+mwrZjm9WPE7Zqcqi/hTXS+7UHBXpVoz0k1kYXezCjf4tbX9EJ542ncI3iby3eFbSh4uDphuDlvcUeL9nb+y36FD7/soKVL+m+t2q027zUv0hQVoA4Xe63urp64OCASvedmKTTWBWYjzQEhXJx8pIlfnXKppkNWFFTQp7uLMguQlBunk7h3rHHP1cigy0Es0OUXd9l7f/8ZrlFi/tmPZ1P0488uCAEsFM83SUHggk0edQvTxMFYNTZ07+A8jdJSh0okvIbzy6PBrN2DmIMoVrwro9d5i/Ek59BULwjlV5bXffcRqsiM2jcl4ueA6t60u0r8JX4onMTVEOQxX/51q2yZX+tNo186eHJUIlCE006R+Sj/J5oG6ErXuJqypcthZkMytTRprRNRx8ALcKVnnyqUQR8GbDyfKtzWqqZ8wutwmWyUqlFDmHei0l9MHbPzu2uiyzH7xN0YGNCcWqdHzcmTL1nVwATB7++cSdO22sfvATQGTPUljeS5/ed+d0WW2U7eL8u7vCJVjciC89R9YHHFUkBIeZz8MCr7GHb/zdLsm6DeiT0dAHQvYuYc6Q8nlrBoGbUxqWN2jA5BbLQdZTr+9q/LTSBIUsRC+6gEiuY/MnrlJ8lztL4NWD7lMCQZG5OSVdkpscW7qA3IHTLk=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
 sudo: required
-
-services:
-  - docker
   
 python:
   - '3.5'
@@ -14,16 +11,19 @@ install:
   
 jobs:
   include:
-    - stage: "Tests"
+    - stage: test
       name: "Test Python 3.5"
+      services: docker
       python: '3.5'
       script: make test
     - name: "Test Python 3.6"
+      services: docker
       python: '3.6'
       script: make test
       
     - stage: deploy
       name: "Deploy to PyPI"
+      services: docker
       if: (tag =~ ^v) AND (branch = master)
       python: '3.6'
       provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 sudo: required
+
+services:
+  - docker
   
 python:
   - '3.5'
@@ -9,22 +12,17 @@ install:
   - pip install -r requirements_dev.txt
   - python3 setup.py install
   
+script: make test
+
+stages:
+  - test
+  - name: deploy
+    if: (tag =~ ^v) AND (branch = master)
+  
 jobs:
-  include:
-    - stage: test
-      name: "Test Python 3.5"
-      services: docker
-      python: '3.5'
-      script: make test
-    - name: "Test Python 3.6"
-      services: docker
-      python: '3.6'
-      script: make test
-      
+  include:      
     - stage: deploy
       name: "Deploy to PyPI"
-      services: docker
-      if: (tag =~ ^v) AND (branch = master)
       python: '3.6'
       provider: pypi
       distributions: "sdist bdist_wheel"


### PR DESCRIPTION
Current pattern causes the deploy to be attempted once per Python version, which in turn causes a failure on one of the builds (whichever finishes second).  This should hopefully fix that by causing deployments to only run once.

## Description
Switch to Travis jobs syntax.

## How Has This Been Tested?
Deployment hasn't yet been tested, but test jobs were tested in `travis-jobs` branch.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
