### PR TITLE
Option to remember the MFA device

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A configuration wizard will prompt you to enter the necessary configuration para
   - call - OTP via Voice call
   - sms - OTP via SMS message
 - resolve_aws_alias - y or n. If yes, gimme-aws-creds will try to resolve AWS account ids with respective alias names (default: n). This option can also be set interactively in the command line using `-r` or `--resolve parameter`
+- remember_device - y or n. If yes, the MFA device will be remembered by Okta service for a limited time. This option can also be set interactively in the command line using `-m` or `--remember-device`
 
 ## Usage
 

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -55,6 +55,7 @@ class OktaClient(object):
         self._username = None
         self._preferred_mfa_type = None
         self._mfa_code = None
+        self._remember_device = None
 
         self._use_oauth_access_token = False
         self._use_oauth_id_token = False
@@ -83,6 +84,9 @@ class OktaClient(object):
 
     def set_mfa_code(self, mfa_code):
         self._mfa_code = mfa_code
+
+    def set_remember_device(self, remember_device):
+        self._remember_device = remember_device
 
     def use_oauth_access_token(self, val=True):
         self._use_oauth_access_token = val
@@ -323,6 +327,7 @@ class OktaClient(object):
         """ Send SMS message for second factor authentication"""
         response = self._http_client.post(
             factor['_links']['verify']['href'],
+            params={'rememberDevice': self._remember_device},
             json={'stateToken': state_token},
             headers=self._get_headers(),
             verify=self._verify_ssl_certs
@@ -340,6 +345,7 @@ class OktaClient(object):
         """ Send Voice call for second factor authentication"""
         response = self._http_client.post(
             factor['_links']['verify']['href'],
+            params={'rememberDevice': self._remember_device},
             json={'stateToken': state_token},
             headers=self._get_headers(),
             verify=self._verify_ssl_certs
@@ -353,11 +359,11 @@ class OktaClient(object):
         if 'sessionToken' in response_data:
             return {'stateToken': None, 'sessionToken': response_data['sessionToken'], 'apiResponse': response_data}
 
-
     def _login_send_push(self, state_token, factor):
         """ Send 'push' for the Okta Verify mobile app """
         response = self._http_client.post(
             factor['_links']['verify']['href'],
+            params={'rememberDevice': self._remember_device},
             json={'stateToken': state_token},
             headers=self._get_headers(),
             verify=self._verify_ssl_certs
@@ -393,6 +399,7 @@ class OktaClient(object):
             pass_code = input()
         response = self._http_client.post(
             next_url,
+            params={'rememberDevice': self._remember_device},
             json={'stateToken': state_token, 'passCode': pass_code},
             headers=self._get_headers(),
             verify=self._verify_ssl_certs

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,9 +21,21 @@ class TestConfig(unittest.TestCase):
         """Run Clean Up"""
         self.config.clean_up()
 
-    @patch('argparse.ArgumentParser.parse_args',
-           return_value=argparse.Namespace(username='ann', configure=False, profile=None, insecure=False, resolve=None, mfa_code=None, register_device=False, list_profiles=False))
+    @patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=argparse.Namespace(
+            username="ann",
+            configure=False,
+            profile=None,
+            insecure=False,
+            resolve=None,
+            mfa_code=None,
+            register_device=False,
+            list_profiles=False,
+            remember_device=False,
+        ),
+    )
     def test_get_args_username(self, mock_arg):
         """Test to make sure username gets returned"""
         self.config.get_args()
-        assert_equals(self.config.username, 'ann')
+        assert_equals(self.config.username, "ann")


### PR DESCRIPTION
## Description
According to the documentation, the MFA device could be remembered for a
limited time if user asks for it.

This PR implements it.

+info:

https://developer.okta.com/docs/api/resources/authn#verify-factor

## Related Issue

Solves #109.

## How Has This Been Tested?

I made some tests with my work accounts.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.