### PR TITLE
add cmd file for windows

### DIFF
--- a/bin/gimme-aws-creds.cmd
+++ b/bin/gimme-aws-creds.cmd
@@ -1,0 +1,50 @@
+@echo OFF
+REM="""
+setlocal
+set PythonExe=""
+set PythonExeFlags=
+
+for %%i in (cmd bat exe) do (
+    for %%j in (python.%%i) do (
+        call :SetPythonExe "%%~$PATH:j"
+    )
+)
+for /f "tokens=2 delims==" %%i in ('assoc .py') do (
+    for /f "tokens=2 delims==" %%j in ('ftype %%i') do (
+        for /f "tokens=1" %%k in ("%%j") do (
+            call :SetPythonExe %%k
+        )
+    )
+)
+%PythonExe% -x %PythonExeFlags% "%~f0" %*
+exit /B %ERRORLEVEL%
+goto :EOF
+
+:SetPythonExe
+if not ["%~1"]==[""] (
+    if [%PythonExe%]==[""] (
+        set PythonExe="%~1"
+    )
+)
+goto :EOF
+"""
+
+"""
+Copyright 2016-present Nike, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and* limitations under the License.*
+"""
+from gimme_aws_creds.main import GimmeAWSCreds
+
+if __name__ == '__main__':
+    try:
+        GimmeAWSCreds().run()
+    except KeyboardInterrupt:
+        pass 
+


### PR DESCRIPTION
## Description
On my windows 10 computer,  I have to provide the full path to the python script:
`python \path\to\scripts\gimme-aws-creds.py`

## Solution
Add a windows cmd file (based on the AWS CLI cmd file) so that executing `gimme-aws-creds` will be enough when the python Scripts dir is on the path