### PR TITLE
fixed case of `all` in get aws rolename

### DIFF
--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -372,7 +372,7 @@ class Config(object):
 
     def _get_aws_rolename(self, default_entry):
         """ Get the AWS Role ARN"""
-        print("Enter the ARN for the AWS role you want credentials for. 'ALL' will retrieve all roles."
+        print("Enter the ARN for the AWS role you want credentials for. 'all' will retrieve all roles."
               "\nThis is optional, you can select the role when you run the CLI.")
         aws_rolename = self._get_user_input("AWS Role ARN", default_entry)
         return aws_rolename


### PR DESCRIPTION
case was incorrect up in example for get AWS rolename.

## Description
changed case of `ALL`

## Motivation and Context
incorrect case usage leads to failed retrieval of roles

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
