### PR TITLE
Add MANIFEST.in for sdist packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include LICENSE.txt
+include requirements.txt


### PR DESCRIPTION
## Description
Add a `MANIFEST.in` to ensure that key files are shipped in the `sdist` source package shipped to pypi.org. The `requirements.txt` as used by `setup.py` is currently missing. 

## Related Issue
This fixed an issue experience while packaging `gimme-aws-creds` for homebrew https://github.com/Homebrew/homebrew-core/pull/41900

## Motivation and Context
Fixes missing `requirements.txt` in source distribution package on pypi.org (pip)

## How Has This Been Tested?
Confirmed that `sdist` now includes the missing files.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.