### PR TITLE
Allow setting AWS profile through CRED_PROFILE env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,15 +138,15 @@ If all goes well you will get your temporary AWS access, secret key and token, t
 
 You can always run `gimme-aws-creds --help` for all the available options.
 
-Alternatively, you can overwrite values in the config section with environment variables for instances where say you may want to change the duration of your token. 
-A list of values of to change with environment variables are: `'OKTA_AUTH_SERVER', 'CLIENT_ID','OKTA_USERNAME', 'AWS_DEFAULT_DURATION'`. 
+Alternatively, you can overwrite values in the config section with environment variables for instances where say you may want to change the duration of your token.
+A list of values of to change with environment variables are: `'OKTA_AUTH_SERVER', 'CLIENT_ID','OKTA_USERNAME', 'AWS_DEFAULT_DURATION'`, `'CRED_PROFILE'`.
 
 Example: `CLIENT_ID='foobar' AWS_DEFAULT_DURATION=12345 gimme-aws-creds`
 
 For changing variables outside of this, you'd need to create a separate profile altogether with `gimme-aws-creds --configure --profile profileName`
 
 ### Viewing Profiles
-Run `gimme-aws-creds --list-profiles` will go to your okta config file and print out all profiles created and their settings. 
+Run `gimme-aws-creds --list-profiles` will go to your okta config file and print out all profiles created and their settings.
 
 ## Running Tests
 

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -81,7 +81,8 @@ class GimmeAWSCreds(object):
     AWS_CONFIG = os.environ.get('AWS_SHARED_CREDENTIALS_FILE', os.path.join(FILE_ROOT, '.aws/credentials'))
     resolver = DefaultResolver()
     envvar_list = ['OKTA_AUTH_SERVER', 'CLIENT_ID',
-                   'OKTA_USERNAME', 'AWS_DEFAULT_DURATION']
+                   'OKTA_USERNAME', 'AWS_DEFAULT_DURATION',
+                   'CRED_PROFILE']
 
     #  this is modified code from https://github.com/nimbusscale/okta_aws_login
     def _write_aws_creds(self, profile, access_key, secret_key, token):


### PR DESCRIPTION
## Description
Allow setting up AWS profile through CRED_PROFILE

## Motivation and Context
We'd like to have more flexibility in choosing what AWS profile we'd like to modify

## How Has This Been Tested?
Locally I was able to associate credentials with a custom AWS profile

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
