### PR TITLE
adding options for arn-only

### DIFF
--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -37,6 +37,7 @@ class Config(object):
         self.api_key = None
         self.conf_profile = 'DEFAULT'
         self.verify_ssl_certs = True
+        self.arn_only= False
         self.app_url = None
         self.resolve = False
         self.mfa_code = None
@@ -65,6 +66,11 @@ class Config(object):
             '--configure', '-c',
             action='store_true',
             help="If set, will prompt user for configuration parameters and then exit."
+        )
+        parser.add_argument(
+            '--arn-only','-a',
+            action='store_true',
+            help="If set, will only set up your roles in your aws config file"
         )
         parser.add_argument(
             '--register-device',
@@ -128,6 +134,8 @@ class Config(object):
             self.remember_device = True
         if args.resolve is True:
             self.resolve = True
+        if args.arn_only is True:
+            self.arn_only = True
         self.conf_profile = args.profile or 'DEFAULT'
 
     def get_config_dict(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,6 +28,7 @@ class TestConfig(unittest.TestCase):
             configure=False,
             profile=None,
             insecure=False,
+            arn_only=False,
             resolve=None,
             mfa_code=None,
             register_device=False,


### PR DESCRIPTION
## Description
Allows for the project to configure arn roles in the aws config file.

## Related Issue
https://github.com/Nike-Inc/gimme-aws-creds/issues/126

## Motivation and Context
Allows for the configuration of arns for transparent authentication when in use with `aws-okta`

## How Has This Been Tested?
Tested locally for expected behavior, being roles are created with AWS profiles in place for use in multiple tools and the aws cli.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
