### PR TITLE
Improved Factor and Device Token Handling

### DIFF
--- a/gimme_aws_creds/__init__.py
+++ b/gimme_aws_creds/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['config', 'okta', 'main', 'ui']
-version = '2.0.0'
+version = '2.0.1'


### PR DESCRIPTION
If the desired preferred factor doesn't exist, it will now list all available factors instead of displaying an empty list.  Further, if a device token doesn't exist in the configuration file, it will be created on the first run instead of requiring the user to run the tool again with the `--action-register-device` flag.

## Related Issue
#93 

## Motivation and Context
Bad user experience having to run the tool again for the device token, and then an even worse experience when shown an empty list of factors, and no good reason as to why.

## How Has This Been Tested?
Unit and user acceptance testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
