### PR TITLE
Add support for token:hardware MFA

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ A configuration wizard will prompt you to enter the necessary configuration para
 - preferred_mfa_type - automatically select a particular  device when prompted for MFA:
   - push - Okta Verify App push
   - token:software:totp - OTP using the Okta Verify App
+  - token:hardware - OTP using hardware like Yubikey
   - call - OTP via Voice call
   - sms - OTP via SMS message
 - resolve_aws_alias - y or n. If yes, gimme-aws-creds will try to resolve AWS account ids with respective alias names (default: n). This option can also be set interactively in the command line using `-r` or `--resolve` parameter

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -429,6 +429,8 @@ class OktaClient(object):
             return self._login_input_webauthn_challenge(state_token, factor)
         elif factor['factorType'] == 'webauthn':
             return self._login_input_webauthn_challenge(state_token, factor)
+        elif factor['factorType'] == 'token:hardware':
+            return self._login_input_mfa_challenge(state_token, factor['_links']['verify']['href'])
 
     def _login_input_mfa_challenge(self, state_token, next_url):
         """ Submit verification code for SMS or TOTP authentication methods"""
@@ -672,6 +674,8 @@ class OktaClient(object):
             return factor['factorType'] + ": " + factor['factorType']
         elif factor['factorType'] == 'webauthn':
             return factor['factorType'] + ": " + factor['factorType']        
+        elif factor['factorType'] == 'token:hardware':
+            return factor['factorType'] + ": " + factor['provider']
         else:
             return "Unknown MFA type: " + factor['factorType']
 

--- a/tests/test_okta_client.py
+++ b/tests/test_okta_client.py
@@ -112,6 +112,26 @@ class TestOktaClient(unittest.TestCase):
                 }
             }
 
+        self.hardware_factor = {
+                'id': 'ykfb7c5ujftQeL9B51t9',
+                'factorType': 'token:hardware',
+                'provider': 'YUBICO',
+                'vendorName': 'YUBICO',
+                'profile': {
+                    'credentialId': '000009884014'
+                 },
+                '_links': {
+                    'verify': {
+                        'href': 'https://datto.okta.com/api/v1/authn/factors/ykfb0c5ujftWeL9X51t7/verify',
+                        'hints': {
+                            'allow': [
+                                'POST'
+                            ]
+                        }
+                    }
+                }
+            }
+
         self.unknown_factor = {
                 "id": "ost9ei4toqQBAzXmw0h7",
                 "factorType": "UNKNOWN_FACTOR",
@@ -712,6 +732,11 @@ class TestOktaClient(unittest.TestCase):
         """ Test building a display name for TOTP"""
         result = self.client._build_factor_name(self.totp_factor)
         assert_equals(result, "token:software:totp( OKTA ) : jane.doe@example.com")
+
+    def test_build_factor_name_hardware(self):
+        """ Test building a display name for hardware"""
+        result = self.client._build_factor_name(self.hardware_factor)
+        assert_equals(result, "token:hardware: YUBICO")
 
     def test_build_factor_name_unknown(self):
         """ Handle an unknown MFA factor"""


### PR DESCRIPTION
## Description
Enable users of gimme-aws-creds to use token:hardware for MFA

## Related Issue
https://github.com/Nike-Inc/gimme-aws-creds/issues/117

## Motivation and Context
Currently a Yubikey can't be used for MFA with gimme-aws-creds. This change lets people use another form of MFA (token:hardware).

## How Has This Been Tested?
This change was tested by using a Yubikey to confirm my identity and obtain credentials. Then I tested that the credentials written to my AWS profile allowed me to gain access. I also ran the automated test suite.

## Screenshots (if appropriate):
![gimme_aws_creds_yubikey](https://user-images.githubusercontent.com/2564322/67437356-7d2cae80-f5a5-11e9-9433-2a9664bfe372.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
