### PR TITLE
add the ability to have profiles in the configuration file inherit from other profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,25 @@ A configuration wizard will prompt you to enter the necessary configuration para
 - remember_device - y or n. If yes, the MFA device will be remembered by Okta service for a limited time. This option can also be set interactively in the command line using `-m` or `--remember-device`
 - output_format - `json` or `export`, determines default credential output format, can be also specified by `--output-format FORMAT` and `-o FORMAT`. 
 
+## Configuration File
+The config file follows a [configfile](https://docs.python.org/3/library/configparser.html) format.
+By default, it is located in $HOME/.okta_aws_login_config
+
+Example file:
+`
+[myprofile]
+client_id = myclient_id
+`
+
+Configurations can inherit from other configurations to share common configuration parameters.
+`
+[my-base-profile]
+client_id = myclient_id
+[myprofile]
+inherit = my-base-profile
+aws_rolename = my-role
+`
+
 ## Usage
 
 **If you are not using gimme-creds-lambda nor using appurl settings, make sure you set the OKTA_API_KEY environment variable.**

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -176,7 +176,20 @@ class Config(object):
             config.read(self.OKTA_CONFIG)
 
             try:
-                return dict(config[self.conf_profile])
+                profile_config = dict(config[self.conf_profile])
+                if "inherits" in profile_config.keys():
+                    print("using inherited config: " + profile_config["inherits"])
+                    if profile_config["inherits"] not in config:
+                        raise errors.GimmeAWSCredsError(self.conf_profile + " inherits from " + profile_config["inherits"] + ", but could not find " + profile_config["inherits"])
+                    combined_config = {
+                        **dict(config[profile_config["inherits"]]),
+                        **profile_config,
+                    }
+                    del combined_config["inherits"]
+                    return combined_config
+                else:
+                    return profile_config
+
             except KeyError:
                 raise errors.GimmeAWSCredsError(
                     'Configuration profile not found! Use the --action-configure flag to generate the profile.')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 """Unit tests for gimme_aws_creds.config.Config"""
 import argparse
 import unittest
+import tempfile
 
 from mock import patch
 from nose.tools import assert_equals
@@ -43,3 +44,50 @@ class TestConfig(unittest.TestCase):
         """Test to make sure username gets returned"""
         self.config.get_args()
         assert_equals(self.config.username, "ann")
+
+    def test_read_config(self):
+        """Test to make sure getting config works"""
+        test_ui = MockUserInterface(argv = [
+            "--profile",
+            "myprofile",
+        ])
+        with open(test_ui.HOME + "/.okta_aws_login_config", "w") as config_file:
+            config_file.write("""
+[myprofile]
+client_id = foo
+""")
+        config = Config(gac_ui=test_ui, create_config=False)
+        config.conf_profile = "myprofile"
+        profile_config = config.get_config_dict()
+        self.assertEqual(profile_config, {"client_id": "foo"})
+
+    def test_read_config_inherited(self):
+        """Test to make sure getting config works when inherited"""
+        test_ui = MockUserInterface(argv = [
+            "--profile",
+            "myprofile",
+        ])
+        with open(test_ui.HOME + "/.okta_aws_login_config", "w") as config_file:
+            config_file.write("""
+[mybase]
+client_id = bar
+aws_appname = baz
+[myprofile]
+inherits = mybase
+client_id = foo
+aws_rolename = myrole
+""")
+        config = Config(gac_ui=test_ui, create_config=False)
+        config.conf_profile = "myprofile"
+        profile_config = config.get_config_dict()
+        self.assertEqual(profile_config, {
+            "client_id": "foo",
+            "aws_appname": "baz",
+            "aws_rolename": "myrole",
+        })
+
+class MockUserInterface(ui.UserInterface):
+
+    def __init__(self, argv):
+        super().__init__(environ={}, argv=argv)
+        self.HOME = tempfile.mkdtemp()


### PR DESCRIPTION
## Description
Adds an additional configuration to allow inherited profiles to simplify down the configuration file

## Motivation and Context
With lots of accounts, many of them may share common configurations. This will help keep the config file more DRY.

## How Has This Been Tested?
There are unit tests added as well as testing down on my local instance (python3 ubuntu wsl).

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
