### PR TITLE
Adding DUO MFA support based on aws_okta_keyman

### DIFF
--- a/gimme_aws_creds/duo.py
+++ b/gimme_aws_creds/duo.py
@@ -1,0 +1,276 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2018 Nathan V
+# https://github.com/nathan-v/aws_okta_keyman
+"""All the Duo things."""
+
+import sys
+import time
+from multiprocessing import Process
+
+import requests
+
+if sys.version_info[0] < 3:  # pragma: no cover
+    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+else:  # pragma: no cover
+    from http.server import HTTPServer, BaseHTTPRequestHandler
+
+
+class PasscodeRequired(BaseException):
+    """A 2FA Passcode Must Be Entered"""
+
+    def __init__(self, factor, state_token):
+        self.factor = factor
+        self.state_token = state_token
+        super(PasscodeRequired, self).__init__()
+
+
+class FactorRequired(BaseException):
+    """A 2FA Factor Must Be Entered"""
+
+    def __init__(self, factor, state_token):
+        self.factor = factor
+        self.state_token = state_token
+        super(FactorRequired, self).__init__()
+
+
+class QuietHandler(BaseHTTPRequestHandler, object):
+    """We have to do this HTTP sever silliness because the Duo widget has to be
+    presented over HTTP or HTTPS or the callback won't work.
+    """
+
+    def __init__(self, html, *args):
+        self.html = html
+        super(QuietHandler, self).__init__(*args)
+
+    def log_message(self, _format, *args):
+        """Mute the server log."""
+
+    def do_GET(self):
+        """Handle the GET and displays the Duo iframe."""
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        self.wfile.write(self.html.encode('utf-8'))
+
+
+class Duo:
+    """Does all the background work needed to serve the Duo iframe."""
+
+    def __init__(self, details, state_token, factor=None):
+        self.details = details
+        self.token = state_token
+        self.factor = factor
+        self.html = None
+        self.session = requests.Session()
+
+    def trigger_web_duo(self):
+        """Start the webserver with the data needed to display the Duo
+        iframe for the user to see.
+        """
+        host = self.details['host']
+        sig = self.details['signature']
+        script = self.details['_links']['script']['href']
+        callback = self.details['_links']['complete']['href']
+
+        self.html = '''<p style="text-align:center">You may close this
+         after the next page loads successfully</p>
+        <iframe id="duo_iframe" style="margin: 0 auto;display:block;"
+        width="620" height="330" frameborder="0"></iframe>
+        <form method="POST" id="duo_form" action="{cb}">
+        <input type="hidden" name="stateToken" value="{tkn}" /></form>
+        <script src="{scr}"></script><script>Duo.init(
+          {{'host': '{hst}','sig_request': '{sig}','post_action': '{cb}'}}
+        );</script>'''.format(tkn=self.token, scr=script,
+                              hst=host, sig=sig,
+                              cb=callback)
+
+        proc = Process(target=self.duo_webserver)
+        proc.start()
+        time.sleep(10)
+        proc.terminate()
+
+    def duo_webserver(self):
+        """HTTP webserver."""
+        server_address = ('127.0.0.1', 65432)
+        httpd = HTTPServer(server_address, self.handler_with_html)
+        httpd.serve_forever()
+
+    def handler_with_html(self, *args):
+        """Call the handler and include the HTML."""
+        QuietHandler(self.html, *args)
+
+    def trigger_duo(self, passcode=""):
+        """Try to get a Duo Push without needing an iframe
+
+        Args:
+            passcode: String passcode to pass along to the OTP factor
+        """
+        sid = self.do_auth(None, None)
+        if self.factor == "call":
+            transaction_id = self.get_txid(sid, "Phone+Call")
+        elif self.factor == "passcode":
+            if passcode:
+                transaction_id = self.get_txid(sid, "Passcode", passcode)
+            else:
+                raise Exception("Cannot use passcode without one provided")
+        elif self.factor == "push":
+            transaction_id = self.get_txid(sid, "Duo+Push")
+        else:
+            raise Exception("Requested Duo factor not supported")
+        auth = self.get_status(transaction_id, sid)
+        return auth
+
+    def do_auth(self, sid, certs_url):
+        """Handle initial auth with Duo
+
+        Args:
+            sid: String Duo session ID if we have it
+            certs_url: String certificates URL if we have it
+
+        Returns:
+            String Duo session ID
+        """
+        txid = self.details['signature'].split(":")[0]
+        fake_path = 'http://0.0.0.0:3000/duo&v=2.1'
+        url = "https://{}/frame/web/v1/auth?tx={}&parent={}".format(
+            self.details['host'], txid, fake_path)
+
+        if sid and certs_url:
+            self.session.params = {sid: sid, certs_url: certs_url}
+
+        self.session.headers = {
+            'Origin': "https://{}".format(self.details['host']),
+            'Content-Type': "application/x-www-form-urlencoded"
+        }
+
+        ret = self.session.post(url, allow_redirects=False)
+
+        if ret.status_code == 302:
+            try:
+                location = ret.headers['Location']
+                sid = location.split("=")[1]
+            except KeyError:
+                raise Exception("Location missing from auth response header.")
+        elif ret.status_code == 200 and sid is None:
+            sid = ret.json()['response']['sid']
+            certs_url = ret.json()['response']['certs_url']
+            sid = self.do_auth(sid, certs_url)
+        else:
+            raise Exception("Duo request failed.")
+
+        return sid
+
+    def get_txid(self, sid, factor, passcode=None):
+        """Get Duo transaction ID
+
+        Args:
+            sid: String Duo session ID
+            factor: String to tell Duo which factor to use
+            passcode: OTP passcode string
+
+        Returns:
+            String Duo transaction ID
+        """
+        url = "https://{}/frame/prompt".format(self.details['host'])
+        self.session.headers = {
+            'Origin': "https://{}".format(self.details['host']),
+            'Content-Type': "application/x-www-form-urlencoded",
+            'X-Requested-With': 'XMLHttpRequest'
+        }
+
+        params = (
+            "sid={}&device=phone1&"
+            "factor={}&out_of_date=False").format(sid, factor)
+
+        if passcode:
+            params = "{}&passcode={}".format(params, passcode)
+
+        url = "{}?{}".format(url, params)
+
+        ret = self.session.post(url)
+        return ret.json()['response']['txid']
+
+    def get_status(self, transaction_id, sid):
+        """Get Duo auth status
+
+        Args:
+            transaction_id: String Duo transaction ID
+            sid: String Duo session ID
+
+        Returns:
+            String authorization from Duo to use in the Okta callback
+        """
+        url = "https://{}/frame/status".format(self.details['host'])
+        self.session.headers = {
+            'Origin': "https://{}".format(self.details['host']),
+            'Content-Type': "application/x-www-form-urlencoded",
+            'X-Requested-With': 'XMLHttpRequest'
+        }
+
+        params = "sid={}&txid={}".format(sid, transaction_id)
+
+        url = "{}?{}".format(url, params)
+
+        tries = 0
+        auth = None
+        while auth is None and tries < 30:
+            tries += 1
+            ret = self.session.post(url)
+
+            if ret.status_code != 200:
+                raise Exception("Push request failed with status {}".format(
+                    ret.status_code))
+
+            result = ret.json()
+
+            if result['stat'] == "OK":
+                if 'cookie' in result['response']:
+                    auth = result['response']['cookie']
+                elif 'result_url' in result['response']:
+                    auth = self.do_redirect(
+                        result['response']['result_url'], sid)
+
+            time.sleep(1)
+
+        if auth is None:
+            raise Exception('Did not get callback information from Duo')
+        return auth
+
+    def do_redirect(self, url, sid):
+        """Deal with redirected response from Duo
+
+        Args:
+            url: String URL we need to follow to try and get the auth
+            sid: String duo session ID
+
+        Returns:
+            String Duo authorization to use in the Okta callback
+        """
+        url = "https://{}{}?sid={}".format(self.details['host'], url, sid)
+        self.session.headers = {
+            'Origin': "https://{}".format(self.details['host']),
+            'Content-Type': "application/x-www-form-urlencoded",
+            'X-Requested-With': 'XMLHttpRequest'
+        }
+
+        ret = self.session.post(url)
+
+        if ret.status_code != 200:
+            raise Exception("Bad status from Duo after redirect {}".format(
+                ret.status_code))
+
+        result = ret.json()
+
+        if 'cookie' in result['response']:
+            return result['response']['cookie']

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -116,6 +116,7 @@ class OktaClient(object):
         flow_state = self._get_initial_flow_state(embed_link, state_token)
 
         while flow_state.get('apiResponse', {}).get('status') != 'SUCCESS':
+            time.sleep(0.5)
             flow_state = self._next_login_step(
                 flow_state.get('stateToken'), flow_state.get('apiResponse'))
 

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -464,7 +464,7 @@ class OktaClient(object):
             auth = duo_client.trigger_duo(passcode=passcode)
         else:
             # Duo Auth without the browser
-            self.ui.info("Duo required; check your phone... 📱")
+            self.ui.info("Duo required; check your phone...")
             auth = duo_client.trigger_duo()
 
         if auth is not None:

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -148,7 +148,7 @@ class OktaClient(object):
         while flow_state.get('apiResponse', {}).get('status') != 'SUCCESS':
             time.sleep(0.5)
             flow_state = self._next_login_step(
-                flow_state.get('apiResponse').get('stateToken'), flow_state.get('apiResponse'))
+                flow_state.get('apiResponse', {}).get('stateToken'), flow_state.get('apiResponse'))
 
         return flow_state['apiResponse']
 

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -27,9 +27,8 @@ from requests.adapters import HTTPAdapter, Retry
 
 from gimme_aws_creds.u2f import FactorU2F
 from gimme_aws_creds.webauthn import WebAuthnClient, FakeAssertion
-from . import errors, ui, version
+from . import errors, ui, version, duo
 
-from aws_okta_keyman import duo
 from multiprocessing import Process
 import webbrowser
 

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -29,6 +29,10 @@ from gimme_aws_creds.u2f import FactorU2F
 from gimme_aws_creds.webauthn import WebAuthnClient, FakeAssertion
 from . import errors, ui, version
 
+from aws_okta_keyman import duo
+from multiprocessing import Process
+import webbrowser
+
 
 class OktaClient(object):
     """
@@ -112,7 +116,6 @@ class OktaClient(object):
         flow_state = self._get_initial_flow_state(embed_link, state_token)
 
         while flow_state.get('apiResponse', {}).get('status') != 'SUCCESS':
-            time.sleep(0.5)
             flow_state = self._next_login_step(
                 flow_state.get('stateToken'), flow_state.get('apiResponse'))
 
@@ -144,7 +147,7 @@ class OktaClient(object):
         while flow_state.get('apiResponse', {}).get('status') != 'SUCCESS':
             time.sleep(0.5)
             flow_state = self._next_login_step(
-                flow_state.get('stateToken'), flow_state.get('apiResponse'))
+                flow_state.get('apiResponse').get('stateToken'), flow_state.get('apiResponse'))
 
         return flow_state['apiResponse']
 
@@ -423,6 +426,98 @@ class OktaClient(object):
         if 'sessionToken' in response_data:
             return {'stateToken': None, 'sessionToken': response_data['sessionToken'], 'apiResponse': response_data}
 
+    def _login_duo_challenge(self, state_token, factor):
+        """ Duo MFA challenge """
+
+        if factor['factorType'] is None:
+            # Prompt user for which Duo factor to use
+            raise duo.FactorRequired(id, state_token)
+
+        if factor['factorType'] == "passcode" and not passcode:
+            raise duo.PasscodeRequired(fid, state_token)
+
+        path = '/authn/factors/{fid}/verify'.format(fid=factor['id'])
+        data = {'fid': factor['id'],
+                'stateToken': state_token}
+
+        response = self._http_client.post(factor['_links']['verify']['href'],
+            params={'rememberDevice': self._remember_device},
+            json={'stateToken': state_token},
+            headers=self._get_headers(),
+            verify=self._verify_ssl_certs
+        )
+        response_data = response.json()
+        verification = response_data['_embedded']['factor']['_embedded']['verification']
+
+        auth = None
+        duo_client = duo.Duo(verification, state_token, factor['factorType'])
+        if factor['factorType'] == "web":
+            # Duo Web via local browser
+            self.ui.info("Duo required; opening browser...")
+            proc = Process(target=duo_client.trigger_web_duo)
+            proc.start()
+            time.sleep(2)
+            webbrowser.open_new('http://127.0.0.1:65432/duo.html')
+        elif factor['factorType'] == "passcode":
+            # Duo auth with OTP code without a browser
+            self.ui.info("Duo required; using OTP...")
+            auth = duo_client.trigger_duo(passcode=passcode)
+        else:
+            # Duo Auth without the browser
+            self.ui.info("Duo required; check your phone... 📱")
+            auth = duo_client.trigger_duo()
+
+        if auth is not None:
+            self.mfa_callback(auth, verification, state_token)
+            try:
+                sleep=2
+                while ret['status'] != 'SUCCESS':
+                    self.ui.info("Waiting for MFA success...")
+                    time.sleep(sleep)
+
+                    if response_data.get('factorResult', 'REJECTED') == 'REJECTED':
+                        self.ui.warning("Duo Push REJECTED")
+                        return None
+
+                    if response_data.get('factorResult', 'TIMEOUT') == 'TIMEOUT':
+                        self.ui.warning("Duo Push TIMEOUT")
+                        return None
+
+                    links = response_data.get('_links')
+                    response_data = self._http_client.post(links['next']['href'], data)
+
+            except KeyboardInterrupt:
+                self.ui.warning("User canceled waiting for MFA success.")
+                raise
+
+        if 'stateToken' in response_data:
+            return {'stateToken': response_data['stateToken'], 'apiResponse': response_data}
+        if 'sessionToken' in response_data:
+            return {'stateToken': None, 'sessionToken': response_data['sessionToken'], 'apiResponse': response_data}
+
+        #return None
+
+    def mfa_callback(self, auth, verification, state_token):
+        """Do callback to Okta with the info from the MFA provider
+        Args:
+            auth: String auth from MFA provider to send in the callback
+            verification: Dict of details used in Okta API calls
+            state_token: String Okta state token
+        """
+        app = verification['signature'].split(":")[1]
+        response_sig = "{}:{}".format(auth, app)
+        callback_params = "stateToken={}&sig_response={}".format(
+            state_token, response_sig)
+
+        url = "{}?{}".format(
+            verification['_links']['complete']['href'],
+            callback_params)
+        ret = self._http_client.post(url)
+        if ret.status_code != 200:
+            raise Exception("Bad status from Okta callback {}".format(
+                ret.status_code))
+
+
     def _login_multi_factor(self, state_token, login_data):
         """ handle multi-factor authentication with Okta"""
         factor = self._choose_factor(login_data['_embedded']['factors'])
@@ -442,6 +537,8 @@ class OktaClient(object):
             return self._login_input_webauthn_challenge(state_token, factor)
         elif factor['factorType'] == 'token:hardware':
             return self._login_input_mfa_challenge(state_token, factor['_links']['verify']['href'])
+        elif factor['provider'] == 'DUO':
+            return self._login_duo_challenge(state_token, factor)
 
     def _login_input_mfa_challenge(self, state_token, next_url):
         """ Submit verification code for SMS or TOTP authentication methods"""
@@ -692,6 +789,8 @@ class OktaClient(object):
             return factor['factorType'] + ": " + factor['factorType']        
         elif factor['factorType'] == 'token:hardware':
             return factor['factorType'] + ": " + factor['provider']
+        elif factor['provider'] == 'DUO':
+            return factor['factorType'] + ": " + factor['provider'].capitalize()
         else:
             return "Unknown MFA type: " + factor['factorType']
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ keyring>=10.4.0
 requests>=2.13.0,<3.0.0
 fido2>=0.7.0,<1.0.0
 okta>=0.0.4,<1.0.0
-aws-okta-keyman>=0.7.2,<0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ keyring>=10.4.0
 requests>=2.13.0,<3.0.0
 fido2>=0.7.0,<1.0.0
 okta>=0.0.4,<1.0.0
+aws-okta-keyman>=0.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ keyring>=10.4.0
 requests>=2.13.0,<3.0.0
 fido2>=0.7.0,<1.0.0
 okta>=0.0.4,<1.0.0
-aws-okta-keyman>=0.7.2
+aws-okta-keyman>=0.7.2,<0.8.0


### PR DESCRIPTION
## Description
I'm introducing the code for Duo MFA used in aws_okta_keyman to allow gimme-aws-creds to be used with that provider.

## Related Issue
https://github.com/Nike-Inc/gimme-aws-creds/issues/57

## Motivation and Context
This would resolve the enhancement request needed by many enterprise customers to support Duo MFA

## How Has This Been Tested?
This has been tested using Duo MFA but only for "Push" and "Passcode" methods.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
