### PR TITLE
165 Support Pathless profile names, and account aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ A configuration wizard will prompt you to enter the necessary configuration para
 - write_aws_creds - True or False - If True, the AWS credentials will be written to `~/.aws/credentials` otherwise it will be written to stdout.
 - cred_profile - If writing to the AWS cred file, this sets the name of the AWS credential profile.
   - The reserved word `role` will use the name component of the role arn as the profile name. i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [okta-1234-role] in the aws credentials file
-  - The reserved word `acc-role` will use the name component of the role arn prepended with account number to avoid collisions, i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [123456789012-okta-1234-role] in the aws credentials file
+  - The reserved word `acc-role` will use the name component of the role arn prepended with account number (or alias if `resolve_aws_alias` is set to y) to avoid collisions, i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [123456789012-okta-1234-role], or if `resolve_aws_alias` [<my alias>-okta-1234-role] in the aws credentials file
   - If set to `default` then the temp creds will be stored in the default profile
   - Note: if there are multiple roles, and `default` is selected it will be overwritten multiple times and last role wins. The same happens when `role` is selected and you have many accounts with the same role names. Consider using `acc-role` if this happens.
 - aws_appname - This is optional. The Okta AWS App name, which has the role you want to assume.
@@ -108,6 +108,7 @@ A configuration wizard will prompt you to enter the necessary configuration para
   - call - OTP via Voice call
   - sms - OTP via SMS message
 - resolve_aws_alias - y or n. If yes, gimme-aws-creds will try to resolve AWS account ids with respective alias names (default: n). This option can also be set interactively in the command line using `-r` or `--resolve` parameter
+- include_path - y or n. This is optional. If yes the full role path to the role name will be included in your profile name. (default: n)
 - remember_device - y or n. If yes, the MFA device will be remembered by Okta service for a limited time. This option can also be set interactively in the command line using `-m` or `--remember-device`
 - output_format - `json` or `export`, determines default credential output format, can be also specified by `--output-format FORMAT` and `-o FORMAT`.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ A configuration wizard will prompt you to enter the necessary configuration para
   - call - OTP via Voice call
   - sms - OTP via SMS message
 - resolve_aws_alias - y or n. If yes, gimme-aws-creds will try to resolve AWS account ids with respective alias names (default: n). This option can also be set interactively in the command line using `-r` or `--resolve` parameter
-- include_path - y or n. This is optional. If yes the full role path to the role name will be included in your profile name. (default: n)
+- include_path - (optional) Includes full role path to the role name in AWS credential profile name. (default: n).  If `y`: `<acct>-/some/path/administrator`. If `n`: `<acct>-administrator`
 - remember_device - y or n. If yes, the MFA device will be remembered by Okta service for a limited time. This option can also be set interactively in the command line using `-m` or `--remember-device`
 - output_format - `json` or `export`, determines default credential output format, can be also specified by `--output-format FORMAT` and `-o FORMAT`.
 

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -391,7 +391,7 @@ class Config(object):
         """ Option to include path from rolename """
 
         ui.default.message(
-            "Do you want to include the role path from your role name ?"
+            "Do you want to include full role path to the role name in AWS credential profile name?"
             "\nPlease answer y or n.")
 
         while True:

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -211,6 +211,7 @@ class Config(object):
                 okta_username = Okta username
                 aws_default_duration = Default AWS session duration (3600)
                 preferred_mfa_type = Select this MFA device type automatically
+                include_path - (optional) includes that full role path to the role name for profile
 
         """
         config = configparser.ConfigParser()
@@ -229,6 +230,7 @@ class Config(object):
             'okta_username': '',
             'app_url': '',
             'resolve_aws_alias': 'n',
+            'include_path': 'n',
             'preferred_mfa_type': '',
             'remember_device': 'n',
             'aws_default_duration': '3600',
@@ -262,6 +264,7 @@ class Config(object):
         if config_dict['gimme_creds_server'] != 'appurl':
             config_dict['aws_appname'] = self._get_aws_appname(defaults['aws_appname'])
         config_dict['resolve_aws_alias'] = self._get_resolve_aws_alias(defaults['resolve_aws_alias'])
+        config_dict['include_path'] = self._get_include_path(defaults['include_path'])
         config_dict['aws_rolename'] = self._get_aws_rolename(defaults['aws_rolename'])
         config_dict['okta_username'] = self._get_okta_username(defaults['okta_username'])
         config_dict['aws_default_duration'] = self._get_aws_default_duration(defaults['aws_default_duration'])
@@ -383,6 +386,19 @@ class Config(object):
                 return self._get_user_input_yes_no("Write AWS Credentials", default_entry)
             except ValueError:
                 ui.default.warning("Write AWS Credentials must be either y or n.")
+
+    def _get_include_path(self, default_entry):
+        """ Option to include path from rolename """
+
+        ui.default.message(
+            "Do you want to include the role path from your role name ?"
+            "\nPlease answer y or n.")
+
+        while True:
+            try:
+                return self._get_user_input_yes_no("Include Path", default_entry)
+            except ValueError:
+                ui.default.warning("Include Path must be either y or n.")
 
     def _get_resolve_aws_alias(self, default_entry):
         """ Option to resolve account id to alias """

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -699,24 +699,10 @@ class GimmeAWSCreds(object):
         # set the profile name
         # Note if there are multiple roles
         # it will be overwritten multiple times and last role wins.
-        if self.conf_dict['cred_profile'].lower() == 'default':
-            profile_name = 'default'
-        elif self.conf_dict['cred_profile'].lower() == 'role':
-            profile_name = naming_data['role']
-        elif self.conf_dict['cred_profile'].lower() == 'acc-role':
-            account = naming_data['account']
-            role_name = naming_data['role']
-            path = naming_data['path']
-            if self.conf_dict['resolve_aws_alias']:
-                account_alias = self._get_alias_from_friendly_name(role.friendly_account_name)
-                if account_alias:
-                    account = account_alias
-            if self.conf_dict['include_path'] == 'True':
-                role_name = ''.join([path, role_name])
-            profile_name = '-'.join([account,
-                                     role_name])
-        else:
-            profile_name = self.conf_dict['cred_profile']
+        cred_profile = self.conf_dict['cred_profile'].lower()
+        resolve_alias = self.conf_dict['resolve_aws_alias']
+        include_path = self.conf_dict['include_path']
+        profile_name = self.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role)
 
         return {
             'shared_credentials_file': self.AWS_CONFIG,
@@ -738,6 +724,27 @@ class GimmeAWSCreds(object):
                 'aws_security_token': aws_creds.get('SessionToken', ''),
             } if bool(aws_creds) else {}
         }
+
+    def get_profile_name(self, cred_profile, include_path, naming_data, resolve_alias, role):
+        if cred_profile == 'default':
+            profile_name = 'default'
+        elif cred_profile == 'role':
+            profile_name = naming_data['role']
+        elif cred_profile == 'acc-role':
+            account = naming_data['account']
+            role_name = naming_data['role']
+            path = naming_data['path']
+            if resolve_alias == 'True':
+                account_alias = self._get_alias_from_friendly_name(role.friendly_account_name)
+                if account_alias:
+                    account = account_alias
+            if include_path == 'True':
+                role_name = ''.join([path, role_name])
+            profile_name = '-'.join([account,
+                                     role_name])
+        else:
+            profile_name = cred_profile
+        return profile_name
 
     def iter_selected_aws_credentials(self):
         results = []

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -164,3 +164,85 @@ class TestMain(unittest.TestCase):
         friendly_name = "Account: my-account-org (123456789012)"
         self.assertEqual(creds._get_alias_from_friendly_name(friendly_name), "my-account-org")
 
+
+    def test_get_profile_name_accrole_resolve_alias_do_not_include_paths(self):
+        "Testing the acc-role, with alias resolution, and not including full role path"
+        creds = GimmeAWSCreds()
+        naming_data = {'account': '123456789012', 'role': 'administrator', 'path': '/administrator/'}
+        role = RoleSet(idp='arn:aws:iam::123456789012:saml-provider/my-okta-provider',
+                       role='arn:aws:iam::123456789012:role/administrator/administrator',
+                       friendly_account_name='Account: my-org-master (123456789012)',
+                       friendly_role_name='administrator/administrator')
+        cred_profile = 'acc-role'
+        resolve_alias = 'True'
+        include_path = 'False'
+        self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role), "my-org-master-administrator")
+
+    def test_get_profile_accrole_name_do_not_resolve_alias_do_not_include_paths(self):
+        "Testing the acc-role, without alias resolution, and not including full role path"
+        creds = GimmeAWSCreds()
+        naming_data = {'account': '123456789012', 'role': 'administrator', 'path': '/administrator/'}
+        role = RoleSet(idp='arn:aws:iam::123456789012:saml-provider/my-okta-provider',
+                       role='arn:aws:iam::123456789012:role/administrator/administrator',
+                       friendly_account_name='Account: my-org-master (123456789012)',
+                       friendly_role_name='administrator/administrator')
+        cred_profile = 'acc-role'
+        resolve_alias = 'False'
+        include_path = 'False'
+        self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
+                         "123456789012-administrator")
+
+    def test_get_profile_accrole_name_do_not_resolve_alias_include_paths(self):
+        "Testing the acc-role, without alias resolution, and including full role path"
+        creds = GimmeAWSCreds()
+        naming_data = {'account': '123456789012', 'role': 'administrator', 'path': '/some/long/extended/path/'}
+        role = RoleSet(idp='arn:aws:iam::123456789012:saml-provider/my-okta-provider',
+                       role='arn:aws:iam::123456789012:role/some/long/extended/path/administrator',
+                       friendly_account_name='Account: my-org-master (123456789012)',
+                       friendly_role_name='administrator/administrator')
+        cred_profile = 'acc-role'
+        resolve_alias = 'False'
+        include_path = 'True'
+        self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
+                         "123456789012-/some/long/extended/path/administrator")
+    def test_get_profile_name_role(self):
+        "Testing the role"
+        creds = GimmeAWSCreds()
+        naming_data = {'account': '123456789012', 'role': 'administrator', 'path': '/some/long/extended/path/'}
+        role = RoleSet(idp='arn:aws:iam::123456789012:saml-provider/my-okta-provider',
+                       role='arn:aws:iam::123456789012:role/some/long/extended/path/administrator',
+                       friendly_account_name='Account: my-org-master (123456789012)',
+                       friendly_role_name='administrator/administrator')
+        cred_profile = 'role'
+        resolve_alias = 'False'
+        include_path = 'True'
+        self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
+                         'administrator')
+
+    def test_get_profile_name_default(self):
+        "Testing the default"
+        creds = GimmeAWSCreds()
+        naming_data = {'account': '123456789012', 'role': 'administrator', 'path': '/some/long/extended/path/'}
+        role = RoleSet(idp='arn:aws:iam::123456789012:saml-provider/my-okta-provider',
+                       role='arn:aws:iam::123456789012:role/some/long/extended/path/administrator',
+                       friendly_account_name='Account: my-org-master (123456789012)',
+                       friendly_role_name='administrator/administrator')
+        cred_profile = 'default'
+        resolve_alias = 'False'
+        include_path = 'True'
+        self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
+                         'default')
+
+    def test_get_profile_name_else(self):
+        "testing else statement in get_profile_name"
+        creds = GimmeAWSCreds()
+        naming_data = {'account': '123456789012', 'role': 'administrator', 'path': '/some/long/extended/path/'}
+        role = RoleSet(idp='arn:aws:iam::123456789012:saml-provider/my-okta-provider',
+                       role='arn:aws:iam::123456789012:role/some/long/extended/path/administrator',
+                       friendly_account_name='Account: my-org-master (123456789012)',
+                       friendly_role_name='administrator/administrator')
+        cred_profile = 'foo'
+        resolve_alias = 'False'
+        include_path = 'True'
+        self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
+                         'foo')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -131,13 +131,36 @@ class TestMain(unittest.TestCase):
     def test_get_partition_unkown(self):
         creds = GimmeAWSCreds()
 
-        self.assertRaises(errors.GimmeAWSCredsExitBase, creds._get_partition_from_saml_acs, 'https://signin.amazonaws-foo.com/saml')
+        self.assertRaises(errors.GimmeAWSCredsExitBase, creds._get_partition_from_saml_acs,
+                          'https://signin.amazonaws-foo.com/saml')
 
-    def test_arn_to_account_and_role_name(self):
+    def test_parse_role_arn_base_path(self):
         creds = GimmeAWSCreds()
         arn = "arn:aws:iam::123456789012:role/okta-1234-role"
-        self.assertEqual(creds._get_account_and_rolename_from_arn(arn),
-        {
-            'account': '123456789012',
-            'role': 'okta-1234-role'
-        })
+        self.assertEqual(creds._parse_role_arn(arn),
+                         {
+                             'account': '123456789012',
+                             'path': '/',
+                             'role': 'okta-1234-role'
+                         })
+
+    def test_parse_role_arn_extended_path(self):
+        creds = GimmeAWSCreds()
+        arn = "arn:aws:iam::123456789012:role/a/really/extended/path/okta-1234-role"
+        self.assertEqual(creds._parse_role_arn(arn),
+                         {
+                             'account': '123456789012',
+                             'path': '/a/really/extended/path/',
+                             'role': 'okta-1234-role'
+                         })
+
+    def test_get_alias_from_friendly_name_no_alias(self):
+        creds = GimmeAWSCreds()
+        friendly_name = "Account: 123456789012"
+        self.assertEqual(creds._get_alias_from_friendly_name(friendly_name), None)
+
+    def test_get_alias_from_friendly_name_with_alias(self):
+        creds = GimmeAWSCreds()
+        friendly_name = "Account: my-account-org (123456789012)"
+        self.assertEqual(creds._get_alias_from_friendly_name(friendly_name), "my-account-org")
+


### PR DESCRIPTION
* Add staticmethod to parse friendly name and get account alias
* Update arn parser to split out the path from the role
* Add configuration option to toggle whether to add path to role name

## Description
1. Added new config item:  `include_path' - (optional) includes that full role path to the role name for profile. This toggles whether to include the path in the profile name when writing to .aws/credentials. This defaults to false. 
2. Updated staticmethod `_get_account_and_rolename_from_arn ` -> `_parse_role_arn`. Updated the contract to parse the arn, and split out the path from the role. Method now returns a dict with account, role, and the addition definition path.

3. Added method `_get_alias_from_friendly_name` that if config item `resolve_aws_alias` is True, will parse the friendly name, and return the alias. If a regex match is note found, this method returns None, and profile defaults back to the accound id

4. Updated method `prepare_data` to support building the profile name with/without the path based on the `include_path` config, and support resolving the aws alias in the profile name if ''acc-role and `resolve_aws_alias`  is set. 

5. I updated testing to match changes. 
 
 ## Related Issue
Resolves: https://github.com/Nike-Inc/gimme-aws-creds/issues/165

## Motivation and Context
Current state you can end up with profile names like:

'123456789012-/some/long/path/administrator'
Which is hard to grok, and cumbersome to type in a --profile reference.

My changes would result in a profile of:
`my-master-administrator`

## How Has This Been Tested?

Yes,

I updated  the test for parsing of the arn, to support splitting our the role, account and path.

I added an additional test to certify that if an extended path is passed it parse appropriately.

I added two tests for parsing the alias from the friendly name.
1. that returns the alias if present
2. that returns none, if a match is not found

I also manually tested different configs, toggling the `include_path`,  and `resolve_aws_alias ` to verify results. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
