### PR TITLE
Feature/use dynamic port for duo server

### DIFF
--- a/gimme_aws_creds/duo.py
+++ b/gimme_aws_creds/duo.py
@@ -67,7 +67,8 @@ class QuietHandler(BaseHTTPRequestHandler, object):
 class Duo:
     """Does all the background work needed to serve the Duo iframe."""
 
-    def __init__(self, details, state_token, factor=None):
+    def __init__(self, details, state_token, socket, factor=None,):
+        self.socket = socket
         self.details = details
         self.token = state_token
         self.factor = factor
@@ -94,7 +95,6 @@ class Duo:
         );</script>'''.format(tkn=self.token, scr=script,
                               hst=host, sig=sig,
                               cb=callback)
-
         proc = Process(target=self.duo_webserver)
         proc.start()
         time.sleep(10)
@@ -102,8 +102,7 @@ class Duo:
 
     def duo_webserver(self):
         """HTTP webserver."""
-        server_address = ('127.0.0.1', 65432)
-        httpd = HTTPServer(server_address, self.handler_with_html)
+        httpd = HTTPServer(self.socket, self.handler_with_html)
         httpd.serve_forever()
 
     def handler_with_html(self, *args):

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -31,6 +31,7 @@ from . import errors, ui, version, duo
 
 from multiprocessing import Process
 import webbrowser
+import socket
 
 
 class OktaClient(object):
@@ -426,6 +427,13 @@ class OktaClient(object):
         if 'sessionToken' in response_data:
             return {'stateToken': None, 'sessionToken': response_data['sessionToken'], 'apiResponse': response_data}
 
+    def get_available_socket(self):
+        """Get available socket, but requesting 0 and allowing OS to provide ephemeral open port"""
+        s = socket.socket()
+        s.bind(('127.0.0.1', 0))
+        server_address = s.getsockname()
+        return server_address
+
     def _login_duo_challenge(self, state_token, factor):
         """ Duo MFA challenge """
 
@@ -448,16 +456,17 @@ class OktaClient(object):
         )
         response_data = response.json()
         verification = response_data['_embedded']['factor']['_embedded']['verification']
+        socket_addr = self.get_available_socket()
 
         auth = None
-        duo_client = duo.Duo(verification, state_token, factor['factorType'])
+        duo_client = duo.Duo(verification, state_token, socket_addr, factor['factorType'])
         if factor['factorType'] == "web":
             # Duo Web via local browser
             self.ui.info("Duo required; opening browser...")
             proc = Process(target=duo_client.trigger_web_duo)
             proc.start()
             time.sleep(2)
-            webbrowser.open_new('http://127.0.0.1:65432/duo.html')
+            webbrowser.open_new('http://{host}:{port}/duo.html'.format(host=socket_addr[0], port=socket_addr[1]))
         elif factor['factorType'] == "passcode":
             # Duo auth with OTP code without a browser
             self.ui.info("Duo required; using OTP...")

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -426,8 +426,8 @@ class OktaClient(object):
             return {'stateToken': response_data['stateToken'], 'apiResponse': response_data}
         if 'sessionToken' in response_data:
             return {'stateToken': None, 'sessionToken': response_data['sessionToken'], 'apiResponse': response_data}
-
-    def get_available_socket(self):
+    @staticmethod
+    def get_available_socket():
         """Get available socket, but requesting 0 and allowing OS to provide ephemeral open port"""
         s = socket.socket()
         s.bind(('127.0.0.1', 0))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update logic to request available port from OS rather than hardcoding it. 

## Related Issue
https://github.com/Nike-Inc/gimme-aws-creds/issues/167

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
port clashing when MFA is required multiple times:
```
OSError: [Errno 48] Address already in use
```

## How Has This Been Tested?
I have tested locally and confirmed that webserver acts as expected. Only change is that the port number now is dynamically set.
I have also run the test suite and to confirm no regression. 

The logic I am adding has no business logic, it is just implementing the socket module, I don't think additional tests for that are necessary, because I would not be testing gimme-aws-creds, I would be testing the socket module. 



## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
