### PR TITLE
Fix to remove "raise for status" causing keychain not to be cleaned up + Python 3.8 Error to is not ""

### DIFF
--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -701,7 +701,7 @@ class GimmeAWSCreds(object):
         # it will be overwritten multiple times and last role wins.
         cred_profile = self.conf_dict['cred_profile'].lower()
         resolve_alias = self.conf_dict['resolve_aws_alias']
-        include_path = self.conf_dict['include_path']
+        include_path = self.conf_dict.get('include_path')
         profile_name = self.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role)
 
         return {

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -333,7 +333,6 @@ class OktaClient(object):
             headers=self._get_headers(),
             verify=self._verify_ssl_certs
         )
-        response.raise_for_status()
 
         response_data = response.json()
         if 'errorCode' in response_data:
@@ -760,7 +759,7 @@ class OktaClient(object):
             # print out the factors and let the user select
             for i, factor in enumerate(factors):
                 factor_name = self._build_factor_name(factor)
-                if factor_name is not "":
+                if factor_name != "":
                     self.ui.info('[{}] {}'.format(i, factor_name))
             selection = self.ui.input('Selection: ')
 


### PR DESCRIPTION
Issue #160 : We were raising a status on a bad response that prevented our flow of cleaning up the keychain. This was a regression fix.

## Description
Removed the raise for status; also removed a "is not" warning from PEP and replaced with != for a string literal

## Related Issue
#160

## Motivation and Context
Solves issue #160 where a keychain could get into a bad state, and we'd continue to use that password (without cleaning it out) and error out.

This meant that any time a password was changed or input incorrectly, the keychain needed to be manually cleared in order to use the tool again.

## How Has This Been Tested?
* Ran all of the unit tests (Success)
* Ran gimme-aws-creds on multiple accounts with updates
** with empty keychain
** with invalid keychain entry
** with valid keychain entry

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
