### PR TITLE
Fix bug where invalid cached passwords aren't cleared

### DIFF
--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -336,14 +336,26 @@ class OktaClient(object):
         )
 
         response_data = response.json()
-        if 'errorCode' in response_data:
-            if self.KEYRING_ENABLED:
-                try:
-                    keyring.delete_password(self.KEYRING_SERVICE, creds['username'])
-                except PasswordDeleteError:
-                    pass
+
+        if response.status_code == 200:
+            pass
+
+        # Handle known Okta error codes
+        # ref: https://developer.okta.com/docs/reference/error-codes/#example-errors-listed-by-http-return-code
+        elif response.status_code in [400, 401, 403, 404, 409, 429, 500, 501, 503]:
+            if response_data['errorCode'] == "E0000004":
+                if self.KEYRING_ENABLED:
+                    try:
+                        self.ui.info("Stored password is invalid, clearing.  Please try again")
+                        keyring.delete_password(self.KEYRING_SERVICE, creds['username'])
+                    except PasswordDeleteError:
+                        pass
             raise errors.GimmeAWSCredsError(
                 "LOGIN ERROR: {} | Error Code: {}".format(response_data['errorSummary'], response_data['errorCode']), 2)
+
+        # If the error code isn't one we know how to handle, raise an exception
+        else:
+            response.raise_for_status()
 
         func_result = {'apiResponse': response_data}
         if 'stateToken' in response_data:
@@ -794,7 +806,7 @@ class OktaClient(object):
         elif factor['factorType'] == 'u2f':
             return factor['factorType'] + ": " + factor['factorType']
         elif factor['factorType'] == 'webauthn':
-            return factor['factorType'] + ": " + factor['factorType']        
+            return factor['factorType'] + ": " + factor['factorType']
         elif factor['factorType'] == 'token:hardware':
             return factor['factorType'] + ": " + factor['provider']
         elif factor['provider'] == 'DUO':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes a bug where invalid cached credentials are not properly cleared from the system keyring.

## Description
<!--- Describe your changes in detail -->
I updated the existing function to check for a 401/Okta Error code combo and clear the cached password, rather than immediately throwing an exception.  I also modified the code such that "known" Okta status codes will be gracefully handled and formatted, as opposed to always throwing an exception from requests.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Nike-Inc/gimme-aws-creds/issues/172

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change passes existing tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X ] All new and existing tests passed.
