### PR TITLE
Check input value for OKTA factor choice

### DIFF
--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -770,13 +770,33 @@ class OktaClient(object):
                 factor_name = self._build_factor_name(factor)
                 if factor_name != "":
                     self.ui.info('[{}] {}'.format(i, factor_name))
-            selection = self.ui.input('Selection: ')
+            selection = self._get_user_int_factor_choice(len(factors))
 
         # make sure the choice is valid
-        if int(selection) > len(factors):
+        if selection is None or selection > len(factors):
             raise errors.GimmeAWSCredsError("You made an invalid selection")
 
-        return factors[int(selection)]
+        return factors[selection]
+
+    def _get_user_int_factor_choice(self, max_int, max_retries=5):
+        for _ in range(max_retries):
+            value = self.ui.input('Selection: ')
+            try:
+                selection = int(value.strip())
+            except ValueError:
+                self.ui.warning(
+                    'Invalid selection {!r}, must be an integer value.'.format(value)
+                )
+                continue
+
+            if 0 <= selection <= max_int:
+                return selection
+            else:
+                self.ui.warning(
+                    'Selection {!r} out of range <0, {}>'.format(selection, max_int)
+                )
+
+        return None
 
     @staticmethod
     def _build_factor_name(factor):

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -773,7 +773,7 @@ class OktaClient(object):
             selection = self._get_user_int_factor_choice(len(factors))
 
         # make sure the choice is valid
-        if selection is None or selection > len(factors):
+        if selection is None:
             raise errors.GimmeAWSCredsError("You made an invalid selection")
 
         return factors[selection]

--- a/tests/test_okta_client.py
+++ b/tests/test_okta_client.py
@@ -718,6 +718,12 @@ class TestOktaClient(unittest.TestCase):
         with self.assertRaises(errors.GimmeAWSCredsExitBase):
             result = self.client._choose_factor(self.factor_list)
 
+    @patch('builtins.input', return_value='a')
+    def test_choose_non_number_factor_totp(self, mock_input):
+        """ Test entering a non number value as MFA factor"""
+        with self.assertRaises(errors.GimmeAWSCredsExitBase):
+            result = self.client._choose_factor(self.factor_list)
+
     def test_build_factor_name_sms(self):
         """ Test building a display name for SMS"""
         result = self.client._build_factor_name(self.sms_factor)


### PR DESCRIPTION
Fix a bug which cause the CLI to pop a python stack trace when a non-number input was given when choosing the Okta MFA factor.

## Description
I added check on the input to avoid raising an error in case of non-number string.

## Related Issue
https://github.com/Nike-Inc/gimme-aws-creds/issues/176

## Motivation and Context
It improves user experience as it prevents an "ugly" python stack trace from popping and instead provides clear indications.

## How Has This Been Tested?
Plain unit tests have been used.
It doesn't require any environment change and doesn't affect other area of the code.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
