### PR TITLE
Feature/update credential file permissions

### DIFF
--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -141,6 +141,8 @@ class GimmeAWSCreds(object):
         # Write the updated config file
         with open(aws_config, 'w+') as configfile:
             config.write(configfile)
+        # Update file permissions to secure  sensitive credentials file
+        os.chmod(aws_config, 0o600)
         self.ui.result('Written profile {} to {}'.format(profile, aws_config))
 
     def write_aws_creds_from_data(self, data, aws_config=None):


### PR DESCRIPTION
Adding line to update file permissions to '0600' or 'rw' by the owner only. Similar permissions for an gpg, or ssh key

## Description
Just adding a line to update permissions for aws credentials file. 

## Related Issue
Resolves #180 


## Motivation and Context
If your credentials file is not already created, the gimme-aws-creds script will create it with '0644' permissions which allows anyone on the machine to read the private credentials. It is more secure to use '0600' which restricts reading and writing to just the owner

## How Has This Been Tested?
Small change, I have tested it locally. Works for both existing, and non-existing credential files



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
