### PR TITLE
Trailing forward slash was being consumed as part of the domain name.

### DIFF
--- a/gimme_aws_creds/__init__.py
+++ b/gimme_aws_creds/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['config', 'okta', 'main', 'ui']
-version = '2.3.2'
+version = '2.3.3'

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -87,7 +87,7 @@ class OktaClient(object):
     @device_token.setter
     def device_token(self, device_token):
         if device_token is not None:
-            match = re.search('^https://(.*)/?', self._okta_org_url)
+            match = re.search(r'^https://(.*)/?', self._okta_org_url)
             self._http_client.cookies.set('DT', device_token, domain=match.group(1), path='/')
 
     def set_username(self, username):

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -87,7 +87,7 @@ class OktaClient(object):
     @device_token.setter
     def device_token(self, device_token):
         if device_token is not None:
-            match = re.search('^https://(.*)', self._okta_org_url)
+            match = re.search('^https://(.*)/?', self._okta_org_url)
             self._http_client.cookies.set('DT', device_token, domain=match.group(1), path='/')
 
     def set_username(self, username):


### PR DESCRIPTION
## Description
In the regex handling the parsing of the domain name from the URL, if a trailing slash existed in the `okta_org_url` config parameter, the trailing slash was being consumed as part of the domain.  This was causing the cookie logic to misbehave, since the domains no longer exactly matched.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#150 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Dual MFA prompt is extremely obnoxious, and was preventing the use of SMS.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local testing.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
