### PR TITLE
Preserve case-sensivity in cred_profile name - take #2

### DIFF
--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -699,7 +699,7 @@ class GimmeAWSCreds(object):
         # set the profile name
         # Note if there are multiple roles
         # it will be overwritten multiple times and last role wins.
-        cred_profile = self.conf_dict['cred_profile'].lower()
+        cred_profile = self.conf_dict['cred_profile']
         resolve_alias = self.conf_dict['resolve_aws_alias']
         include_path = self.conf_dict.get('include_path')
         profile_name = self.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role)
@@ -726,11 +726,11 @@ class GimmeAWSCreds(object):
         }
 
     def get_profile_name(self, cred_profile, include_path, naming_data, resolve_alias, role):
-        if cred_profile == 'default':
+        if cred_profile.lower() == 'default':
             profile_name = 'default'
-        elif cred_profile == 'role':
+        elif cred_profile.lower() == 'role':
             profile_name = naming_data['role']
-        elif cred_profile == 'acc-role':
+        elif cred_profile.lower() == 'acc-role':
             account = naming_data['account']
             role_name = naming_data['role']
             path = naming_data['path']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
`gimme_aws_creds` should preserve case-sensivity in _cred_profile_ name

## Description
<!--- Describe your changes in detail -->
We need to preserve case-sensitivity if we specify a custom `cred_profile` name and the custom name isn't equal to one of the 3 managed options: '_default_', '_role_',  '_acc-role_'.
This patch is required in case we're reading the configuration from an existing `gimme_aws_creds` profile
This PR supersede #183
 
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This fix case insensivity in cred_profile name in case we read it from a config file.
This small patch makes gimme_aws_creds coherent between interactive cli usage and when it reads the configuration from a config file.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Small change, I have tested it locally.
Create a config profile with the following parameter:
```
write_aws_creds = True
cred_profile = TeStMe123
```

launch `gimme_aws_creds` using the custom profile and check for the aws profile name in _~/.aws/credentials_ 
The case-sensivity of the aws profile name should be preserved.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
