### PR TITLE
Fix Commented export of role arn on some distros and output format

### DIFF
--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -486,7 +486,7 @@ class Config(object):
 
     def _get_output_format(self, default_entry):
         """Get the user's preferred output format [Optional]"""
-        ui.default.message("Set the tools' output format:[bash, json]")
+        ui.default.message("Set the tools' output format:[export, json]")
         output_format = None
         while output_format not in ('export', 'json'):
             output_format = self._get_user_input(

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -787,7 +787,7 @@ class GimmeAWSCreds(object):
                 continue
 
             # Defaults to `export` format
-            self.ui.result('# ' + data['role']['arn'])
+            self.ui.result("export AWS_ROLE_ARN=" + data['role']['arn'])
             self.ui.result("export AWS_ACCESS_KEY_ID=" + data['credentials']['aws_access_key_id'])
             self.ui.result("export AWS_SECRET_ACCESS_KEY=" + data['credentials']['aws_secret_access_key'])
             self.ui.result("export AWS_SESSION_TOKEN=" + data['credentials']['aws_session_token'])


### PR DESCRIPTION
As specified on https://github.com/Nike-Inc/gimme-aws-creds/issues/156, there are some issues with the commented output when we want to set the credentials as environment variables. Exporting the role arn could be useful for some and also fixes the problem. 
The output format showing on the wizzard was showing an incorrect option. 