### PR TITLE
Changed plural 'Pick a Roles' to 'Pick a Role' in dialog

### DIFF
--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -418,7 +418,7 @@ class GimmeAWSCreds(object):
         role_strs = self.resolver._display_role(roles)
 
         if role_strs:
-            self.ui.message("Pick a roles:")
+            self.ui.message("Pick a role:")
             for role in role_strs:
                 self.ui.message(role)
         else:


### PR DESCRIPTION


Signed-off-by: chris dagdigian <dag@sonsorol.org>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Trivial dialog typo -- corrected "Pick a Roles" to "Pick a Role" in the dialog text

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Filed Issue #193 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Typo fix and my first PR for code that I expect to use a lot

## How Has This Been Tested?

Fixed the text typo in a local branch, installed locally and tested against our Okta install 
(see screenshot)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):
![typo-fixed](https://user-images.githubusercontent.com/76222/79780027-4c85c180-8309-11ea-800c-b6864443edfe.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

