### PR TITLE
Fix mfa for custom Okta configuration

### DIFF
--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -718,6 +718,17 @@ class OktaClient(object):
 
                 return saml_response
 
+            elif ('EXTRA VERIFICATION' in saml_soup.find('span').contents[0]) and ('EVHeader' in str(saml_soup.find('span', id='EVHeader'))):
+                # extract the stateToken from the Javascript code in the page and step up to MFA
+                state_token = decode(re.search(r"var StateToken = '(.*)';", response.text).group(1), "unicode-escape")
+                api_response = self.stepup_auth(url, state_token)
+                if 'sessionToken' in api_response:
+                    saml_response = self.get_saml_response(url + '?sessionToken=' + api_response['sessionToken'])
+                else:
+                    saml_response = self.get_saml_response(url + '?stateToken=' + api_response['_links']['next']['href'])
+
+                return saml_response
+
             raise RuntimeError(
                 'Did not receive SAML Response after successful authentication [' + url + ']')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
1) Added a condition to look for "Extra Verification" string in all the response tags
2) Extract the stateToken variable from response or form action instead of javascript variable

## Description

The changes is to fix the issue - https://github.com/Nike-Inc/gimme-aws-creds/issues/182

This tool is not working with mfa prompt in case of custom Okta configuration. There would be a different SAML response for custom Okta configuration and following conditions are not working. 
a) same_soup.title.string does not have Extra Verification string, 
b) we do not have session token in our SAML reponse.
c) Does not find the stateToken variable in javascript as it is can be of different case

## Related Issue
https://github.com/Nike-Inc/gimme-aws-creds/issues/182

## Motivation and Context
This resolves the error "Did not receive SAML Response after successful authentication" for custom Okta configuration. Without this fix, users were not able to use the aws cli tool with mfa authentication.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Testing Done:
Forked the repo to our organization
Applied the changes to fork master
Currently all the users are using the forked tool, it resolves mfa issue and do not see any other issues 
It should not affect the existing code as I have added as a separate condition 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
