### PR TITLE
Add DUO push & passcode Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,14 @@ A configuration wizard will prompt you to enter the necessary configuration para
 - app_url - If using 'appurl' setting for gimme_creds_server, this sets the url to the aws application configured in Okta. It is typically something like <https://something.okta[preview].com/home/amazon_aws/app_instance_id/something>
 - okta_username - use this username to authenticate
 - preferred_mfa_type - automatically select a particular  device when prompted for MFA:
-  - push - Okta Verify App push
+  - push - Okta Verify App push or DUO push (depends on okta supplied provider type)
   - token:software:totp - OTP using the Okta Verify App
   - token:hardware - OTP using hardware like Yubikey
   - call - OTP via Voice call
   - sms - OTP via SMS message
+  - web - DUO uses localhost webbrowser to support push|call|passcode
+  - passcode - DUO uses `OKTA_MFA_CODE` or `--mfa-code` if set, or prompts user for passcode(OTP).
+  
 - resolve_aws_alias - y or n. If yes, gimme-aws-creds will try to resolve AWS account ids with respective alias names (default: n). This option can also be set interactively in the command line using `-r` or `--resolve` parameter
 - include_path - (optional) Includes full role path to the role name in AWS credential profile name. (default: n).  If `y`: `<acct>-/some/path/administrator`. If `n`: `<acct>-administrator`
 - remember_device - y or n. If yes, the MFA device will be remembered by Okta service for a limited time. This option can also be set interactively in the command line using `-m` or `--remember-device`

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -477,7 +477,17 @@ class Config(object):
         """Get the user's preferred MFA device [Optional]"""
         ui.default.message(
             "If you'd like to set a preferred device type to use for MFA, enter it here.\n"
-            "This is optional. valid devices types:[sms, call, push, token, token:software:totp]")
+            "This is optional. valid devices types:\n"
+            """
+            - push - Okta Verify App push or DUO push (depends on okta supplied provider type)
+            - token:software:totp - OTP using the Okta Verify App
+            - token:hardware - OTP using hardware like Yubikey
+            - call - OTP via Voice call
+            - sms - OTP via SMS message
+            - web - DUO uses localhost webbrowser to support push|call|passcode
+            - passcode - DUO uses `OKTA_MFA_CODE` or `--mfa-code` if set, or prompts user for passcode(OTP).
+            """
+        )
         okta_username = self._get_user_input(
             "Preferred MFA Device Type", default_entry)
         return okta_username

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -215,6 +215,7 @@ class OktaClient(object):
             redirect_uri = 'http://localhost:8080/login'
         else:
             redirect_uri = kwargs['redirect_uri']
+            redirect_uri = kwargs['redirect_uri']
 
         if 'nonce' not in kwargs:
             nonce = uuid.uuid4().hex
@@ -435,30 +436,27 @@ class OktaClient(object):
 
     def _login_duo_challenge(self, state_token, factor):
         """ Duo MFA challenge """
-
+        passcode=self._mfa_code
         if factor['factorType'] is None:
             # Prompt user for which Duo factor to use
-            raise duo.FactorRequired(id, state_token)
+            raise duo.FactorRequired(factor['id'], state_token)
 
         if factor['factorType'] == "passcode" and not passcode:
-            raise duo.PasscodeRequired(fid, state_token)
+            try:
+                passcode = self.ui.input("Enter verification code(remember to refresh token between uses): ")
+            except Exception:
+                raise duo.PasscodeRequired(factor['id'], state_token)
 
         path = '/authn/factors/{fid}/verify'.format(fid=factor['id'])
         data = {'fid': factor['id'],
                 'stateToken': state_token}
 
-        response = self._http_client.post(factor['_links']['verify']['href'],
-            params={'rememberDevice': self._remember_device},
-            json={'stateToken': state_token},
-            headers=self._get_headers(),
-            verify=self._verify_ssl_certs
-        )
-        response_data = response.json()
+        response_data = self._get_response_data(factor['_links']['verify']['href'], state_token)
         verification = response_data['_embedded']['factor']['_embedded']['verification']
         socket_addr = self.get_available_socket()
 
         auth = None
-        duo_client = duo.Duo(verification, state_token, socket_addr, factor['factorType'])
+        duo_client = duo.Duo(self.ui, verification, state_token, socket_addr, factor['factorType'])
         if factor['factorType'] == "web":
             # Duo Web via local browser
             self.ui.info("Duo required; opening browser...")
@@ -478,11 +476,8 @@ class OktaClient(object):
         if auth is not None:
             self.mfa_callback(auth, verification, state_token)
             try:
-                sleep=2
-                while ret['status'] != 'SUCCESS':
-                    self.ui.info("Waiting for MFA success...")
-                    time.sleep(sleep)
-
+                response_data = self._get_response_data(response_data.get('_links')['next']['href'], state_token)
+                while response_data['status'] != 'SUCCESS':
                     if response_data.get('factorResult', 'REJECTED') == 'REJECTED':
                         self.ui.warning("Duo Push REJECTED")
                         return None
@@ -491,8 +486,9 @@ class OktaClient(object):
                         self.ui.warning("Duo Push TIMEOUT")
                         return None
 
-                    links = response_data.get('_links')
-                    response_data = self._http_client.post(links['next']['href'], data)
+                    self.ui.info("Waiting for MFA success...")
+                    time.sleep(2)
+                    response_data = self._get_response_data(response_data.get('_links')['next']['href'], state_token)
 
             except KeyboardInterrupt:
                 self.ui.warning("User canceled waiting for MFA success.")
@@ -504,6 +500,16 @@ class OktaClient(object):
             return {'stateToken': None, 'sessionToken': response_data['sessionToken'], 'apiResponse': response_data}
 
         #return None
+
+    def _get_response_data(self, href, state_token):
+        response = self._http_client.post(href,
+                                          params={'rememberDevice': self._remember_device},
+                                          json={'stateToken': state_token},
+                                          headers=self._get_headers(),
+                                          verify=self._verify_ssl_certs
+                                          )
+        response_data = response.json()
+        return response_data
 
     def mfa_callback(self, auth, verification, state_token):
         """Do callback to Okta with the info from the MFA provider
@@ -529,7 +535,9 @@ class OktaClient(object):
     def _login_multi_factor(self, state_token, login_data):
         """ handle multi-factor authentication with Okta"""
         factor = self._choose_factor(login_data['_embedded']['factors'])
-        if factor['factorType'] == 'sms':
+        if factor['provider'] == 'DUO':
+            return self._login_duo_challenge(state_token, factor)
+        elif factor['factorType'] == 'sms':
             return self._login_send_sms(state_token, factor)
         elif factor['factorType'] == 'call':
             return self._login_send_call(state_token, factor)
@@ -545,8 +553,7 @@ class OktaClient(object):
             return self._login_input_webauthn_challenge(state_token, factor)
         elif factor['factorType'] == 'token:hardware':
             return self._login_input_mfa_challenge(state_token, factor['_links']['verify']['href'])
-        elif factor['provider'] == 'DUO':
-            return self._login_duo_challenge(state_token, factor)
+
 
     def _login_input_mfa_challenge(self, state_token, next_url):
         """ Submit verification code for SMS or TOTP authentication methods"""
@@ -751,7 +758,17 @@ class OktaClient(object):
         self.ui.info("Multi-factor Authentication required.")
 
         # filter the factor list down to just the types specified in preferred_mfa_type
+        import copy
         preferred_factors = []
+        # even though duo supports both passcode and push, okta only lists web as an available factor. This if statement
+        # adds the additional supported factors only if the provider is duo, and the web factor is the only one provided
+        if len(factors) == 1 and factors[0].get('provider') == 'DUO' and factors[0].get('factorType') == 'web':
+            push = copy.deepcopy(factors[0])
+            push['factorType'] = "push"
+            factors.append(push)
+            passcode = copy.deepcopy(factors[0])
+            passcode['factorType'] = "passcode"
+            factors.append(passcode)
         if self._preferred_mfa_type is not None:
             preferred_factors = list(filter(lambda item: item['factorType'] == self._preferred_mfa_type, factors))
             # If the preferred factor isn't in the list of available factors, we'll let the user know before
@@ -781,7 +798,9 @@ class OktaClient(object):
     @staticmethod
     def _build_factor_name(factor):
         """ Build the display name for a MFA factor based on the factor type"""
-        if factor['factorType'] == 'push':
+        if factor['provider'] == 'DUO':
+            return factor['factorType'] + ": " + factor['provider'].capitalize()
+        elif factor['factorType'] == 'push':
             return "Okta Verify App: " + factor['profile']['deviceType'] + ": " + factor['profile']['name']
         elif factor['factorType'] == 'sms':
             return factor['factorType'] + ": " + factor['profile']['phoneNumber']
@@ -797,8 +816,7 @@ class OktaClient(object):
             return factor['factorType'] + ": " + factor['factorType']        
         elif factor['factorType'] == 'token:hardware':
             return factor['factorType'] + ": " + factor['provider']
-        elif factor['provider'] == 'DUO':
-            return factor['factorType'] + ": " + factor['provider'].capitalize()
+
         else:
             return "Unknown MFA type: " + factor['factorType']
 

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -32,6 +32,7 @@ from . import errors, ui, version, duo
 from multiprocessing import Process
 import webbrowser
 import socket
+import copy
 
 
 class OktaClient(object):
@@ -214,7 +215,6 @@ class OktaClient(object):
         if 'redirect_uri' not in kwargs:
             redirect_uri = 'http://localhost:8080/login'
         else:
-            redirect_uri = kwargs['redirect_uri']
             redirect_uri = kwargs['redirect_uri']
 
         if 'nonce' not in kwargs:
@@ -758,7 +758,6 @@ class OktaClient(object):
         self.ui.info("Multi-factor Authentication required.")
 
         # filter the factor list down to just the types specified in preferred_mfa_type
-        import copy
         preferred_factors = []
         # even though duo supports both passcode and push, okta only lists web as an available factor. This if statement
         # adds the additional supported factors only if the provider is duo, and the web factor is the only one provided


### PR DESCRIPTION
* Update README
* Update Configure Command
* Add ui/logging to duo Class
* cleanup duo auth logic
* fix broken variable definitions
* Resolves #216

<!--- Provide a general summary of your changes in the Title above -->
Fix Broken Logic for DUO push|passcode 

## Description
### README

1. Update preferred documentation to include duo types including web|push|passcode

### config.py
1. Update ui message for preferred_mfa_type to match README and include descriptions
2. Added DUO types web|push|passcode

### duo.py
1. Added UI/logging to duo class
2. Added logging statement for duo response status
3. Added Error handling for passing a previously used passcode|OTP
4. Fixed sleep logic to only sleep if response status was not successful in order to improve user experience 

### okta.py
1. create default value for `passcode` to fix undefined error.
2. set default value for `passcode` to `self.mfa_code` to leverage  `OKTA_MFA_CODE` | `--mfa_code` functionality
3. fix undefined `id` | `fid` variables by pointing them to factor['id']
4. Add prompt for user to enter pass code if not set via `OKTA_MFA_CODE` | `--mfa_code`
5. created `self._get_response_data` method to make code more DRY
6. Update duo auth status logic to reduce sleeps, and improve user experience
7. Update if statement order in `_login_multi_factor` to ensure that DUO "push" would actually trigger
8. Add in valid duo factors IF duo is the provider, and only `web` is offered.
```
if len(factors) == 1 and factors[0].get('provider') == 'DUO' and factors[0].get('factorType') == 'web':
            push = copy.deepcopy(factors[0])
            push['factorType'] = "push"
            factors.append(push)
            passcode = copy.deepcopy(factors[0])
            passcode['factorType'] = "passcode"
            factors.append(passcode)
```
This is because even though DUO supports these factors, Okta does not provide them as valid factors. This shims them in as valid factors. If Okta in the future provides them as valid factors this if statement will not run because more than 1 factor is returned. 
9. Update the if statement order in `_build_factor_name` to ensure that DUO "push" would be triggered

## Related Issue
Resolves #216 

## Motivation and Context
Currently Duo `push` | `passcode` logic is broken and does not work. Our team would prefer to supply the passcode(OTP), or use the headless push, because the web option opens a browser and does not close.

This could also resolve #159  as workaround to not have to spin up a web browser

## How Has This Been Tested?
I have tested the following:
1. setting `preferred_mfa_type: web` - Worked as expected no regression, window opened and I was able to authenticate. Window did not close
2. setting `preferred_mfa_type: push` - I received a headless duo push ... YAY!
3. setting `preferred_mfa_type: passcode` - I was prompted for a passcode, entered it and successfully authenticated
4. setting `preferred_mfa_type: passcode` & used `OKTA_MFA_CODE` | `--mfa_code to provide the OTP - I was able to authenticate successfully. 
5.  `preferred_mfa_type: passcode` & Used an previously used OTP. - Authentication failed, and I received an error message (via the error handling statement I added) that indicated that I used a old token and needed to try again with a new one
![image](https://user-images.githubusercontent.com/19742213/85944500-625cc780-b8f4-11ea-9abf-a7ebc7885401.png)
6. I set `preferred_mfa_type: None` - I was prompted to choose from three valid options web|passcode|push
![image](https://user-images.githubusercontent.com/19742213/85944460-1e69c280-b8f4-11ea-84f5-573e9dee27a3.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. - Does not look like there is currently a supported method for testing DUO calls via okta.example.com
- [ x] All new and existing tests passed.
