### PR TITLE
Do not write inheritance to config file. Should fix #221

### DIFF
--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -167,8 +167,8 @@ class Config(object):
             self.roles = [role.strip() for role in args.roles.split(',') if role.strip()]
         self.conf_profile = args.profile or 'DEFAULT'
 
-    def _handle_config(self, config, profile_config):
-        if "inherits" in profile_config.keys():
+    def _handle_config(self, config, profile_config, include_inherits = True):
+        if "inherits" in profile_config.keys() and include_inherits:
             print("Using inherited config: " + profile_config["inherits"])
             if profile_config["inherits"] not in config:
                 raise errors.GimmeAWSCredsError(self.conf_profile + " inherits from " + profile_config["inherits"] + ", but could not find " + profile_config["inherits"])
@@ -181,7 +181,7 @@ class Config(object):
         else:
             return profile_config
 
-    def get_config_dict(self):
+    def get_config_dict(self, include_inherits = True):
         """returns the conf dict from the okta config file"""
         # Check to see if config file exists, if not complain and exit
         # If config file does exist return config dict from file
@@ -191,7 +191,7 @@ class Config(object):
 
             try:
                 profile_config = dict(config[self.conf_profile])
-                return self._handle_config(config, profile_config)
+                return self._handle_config(config, profile_config, include_inherits)
             except KeyError:
                 raise errors.GimmeAWSCredsError(
                     'Configuration profile not found! Use the --action-configure flag to generate the profile.')

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -850,9 +850,10 @@ class GimmeAWSCreds(object):
                 self.ui.notify('*** You may be prompted for MFA more than once for this run.\n')
 
             auth_result = self.auth_session
-            self.conf_dict['device_token'] = auth_result['device_token']
-            self.config.write_config_file(self.conf_dict)
-            self.okta.device_token = self.conf_dict['device_token']
+            base_config = self.config.get_config_dict(include_inherits = False)
+            base_config['device_token'] = auth_result['device_token']
+            self.config.write_config_file(base_config)
+            self.okta.device_token = base_config['device_token']
 
             self.ui.notify('\nDevice token saved!\n')
 


### PR DESCRIPTION
When writing `device_token` to profile, only retrieve local profile items, not inherited items.

## Description
In `handle_action_register_device`, do not write the full configuration cache to the profile: only write the new `device_token` and the original profile contents. Prior to this change, writing the `device_token` would overwrite the `inherits` flag and also insert the full inherited configuration.

## Related Issue
https://github.com/Nike-Inc/gimme-aws-creds/issues/221

## Motivation and Context
This change allows top-level configurations to remain relevant after inheritance has occurred.

## How Has This Been Tested?
Verified that all authorizations still work and repeated authorizations still work. Verified that the only modification made to the config file is the addition of the `device_token`. Ran all tests.

```
Ran 56 tests in 0.097s

OK
```

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
