### PR TITLE
Fixing Webauthn broken #228 issue

### DIFF
--- a/gimme_aws_creds/__init__.py
+++ b/gimme_aws_creds/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['config', 'okta', 'main', 'ui']
-version = '2.3.4'
+version = '2.3.5'

--- a/gimme_aws_creds/webauthn.py
+++ b/gimme_aws_creds/webauthn.py
@@ -17,7 +17,7 @@ from threading import Event, Thread
 
 from fido2.client import Fido2Client, ClientError
 from fido2.hid import CtapHidDevice, STATUS
-
+from fido2.webauthn import PublicKeyCredentialRequestOptions
 from gimme_aws_creds.errors import NoFIDODeviceFoundError, FIDODeviceTimeoutError
 
 
@@ -71,9 +71,8 @@ class WebAuthnClient(object):
 
     def work(self, client):
         try:
-            self._assertions, self._client_data = client.get_assertion(
-                self._rp['id'], self._challenge, self._allow_list, timeout=self._cancel, on_keepalive=self.on_keepalive
-            )
+            request_options=PublicKeyCredentialRequestOptions(challenge=base64.urlsafe_b64decode(self._challenge), rp_id=self._rp['id'], allow_credentials=self._allow_list)
+            self._assertions, self._client_data = client.get_assertion(request_options, on_keepalive=self.on_keepalive, event=self._cancel)
         except ClientError as e:
             if e.code == ClientError.ERR.DEVICE_INELIGIBLE:
                 self.ui.info('Security key is ineligible')  # TODO extract key info


### PR DESCRIPTION
Fixing this integration problem with fido2 version 0.8.0. This version need to use `PublicKeyCredentialRequestOptions` when you call get_assertion. 

## Description
1. Import the class `PublicKeyCredentialRequestOptions` on the `webauthn.py`
2. Instantiate `PublicKeyCredentialRequestOptions` on `work` function. 
3. Change `client.get_assertion` call to use `PublicKeyCredentialRequestOptions`.
4. Change `version ` to `2.3.5` on `__init__.py`

## Related Issue
https://github.com/Nike-Inc/gimme-aws-creds/issues/228

## Motivation and Context
If you try to use Yubikey with gimme-aws-creds, you probably (almost certainly) will face an error that prevents you to proceed. The current "workaround" is to downgrade `fido2` to `0.7.3` which leads to this warning: `gimme-aws-creds 2.3.4 has requirement fido2<=0.9.0,>=0.8.0, but you'll have fido2 0.7.3 which is incompatible.`. 

## How Has This Been Tested?
Operating System and version: macOS 10.14.6
1. Plug Yubikey
2. Running the flow code.
`ui = gimme_aws_creds.ui.CLIUserInterface()`
`credentials = gimme_aws_creds.main.GimmeAWSCreds(ui=ui)`
3. Check `credentials`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
