### PR TITLE
Adds a prompt for entering a PIN when a FIDO2 key is PIN protected

### DIFF
--- a/gimme_aws_creds/__init__.py
+++ b/gimme_aws_creds/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['config', 'okta', 'main', 'ui']
-version = '2.3.4'
+version = '2.3.5'

--- a/gimme_aws_creds/webauthn.py
+++ b/gimme_aws_creds/webauthn.py
@@ -17,7 +17,7 @@ from threading import Event, Thread
 
 from fido2.client import Fido2Client, ClientError
 from fido2.hid import CtapHidDevice, STATUS
-
+from fido2.webauthn import PublicKeyCredentialRequestOptions
 from gimme_aws_creds.errors import NoFIDODeviceFoundError, FIDODeviceTimeoutError
 
 
@@ -71,9 +71,8 @@ class WebAuthnClient(object):
 
     def work(self, client):
         try:
-            self._assertions, self._client_data = client.get_assertion(
-                self._rp['id'], self._challenge, self._allow_list, timeout=self._cancel, on_keepalive=self.on_keepalive
-            )
+            request_options=PublicKeyCredentialRequestOptions(challenge=base64.urlsafe_b64decode(self._challenge), rp_id=self._rp['id'], allow_credentials=self._allow_list)
+            self._assertions, self._client_data = client.get_assertion(request_options, on_keepalive=self.on_keepalive, event=self._cancel)
         except ClientError as e:
             if e.code == ClientError.ERR.DEVICE_INELIGIBLE:
                 self.ui.info('Security key is ineligible')  # TODO extract key info


### PR DESCRIPTION
## Description
Adds a prompt for entering a PIN when a FIDO2 key is PIN protected. It's currently rebased on another open PR which fixes compatibility with fido2 0.8.0 #232.

## Related Issue
This resolves #240


## Motivation and Context
Initially encountered a problem when Azure required setting a PIN for FIDO2 key use and then gimme-aws-creds stopped working because it is missing a prompt for PIN.

## How Has This Been Tested?
Have verified that a PIN protected Yubikey 5Ci is workin.
Have verified that a PIN protected Yubikey 5 is working.
Have verified with another Yubikey 5Ci without a PIN set that you are not prompted for a PIN.

Did observe that if both a PIN protected and non-PIN protected key is plugged in to the computer at the same time, you will receive the PIN prompt as the client does not know whether you will need it.

## Screenshots (if appropriate):
```
Using password from keyring for adam@streamsets.com
Multi-factor Authentication required.
webauthn: webauthn selected
Challenge with security keys ...
Please enter PIN: 

Touch your authenticator device now...

Saving arn:aws:iam...
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
