### PR TITLE
fix: return correct exit code on interrupt

### DIFF
--- a/bin/gimme-aws-creds
+++ b/bin/gimme-aws-creds
@@ -16,4 +16,4 @@ if __name__ == '__main__':
     try:
         GimmeAWSCreds().run()
     except KeyboardInterrupt:
-        pass
+        exit(130)

--- a/bin/gimme-aws-creds.cmd
+++ b/bin/gimme-aws-creds.cmd
@@ -46,4 +46,4 @@ if __name__ == '__main__':
     try:
         GimmeAWSCreds().run()
     except KeyboardInterrupt:
-        pass
+        exit(130)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed entry script to return status code 130, instead of 0, on `KeyboardInterrupt`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Nike-Inc/gimme-aws-creds/issues/244

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When used in other scripts that rely on `gimme-aws-creds`, this will enable to distinguish between the credentials being acquired successfully vs `gimme-aws-creds` being interrupted without actually acquiring the credentials.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Made this change locally in my `/usr/local/bin/gimme-aws-creds` (macOS), saw that this now returns the correct status when interrupted.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
