### PR TITLE
fixes to output format if explicitly specified

### DIFF
--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -51,6 +51,7 @@ class Config(object):
         self.action_list_profiles = False
         self.action_list_roles = False
         self.action_store_json_creds = False
+        self.action_output_format = False
         self.output_format = 'export'
         self.roles = []
 
@@ -162,6 +163,7 @@ class Config(object):
         if args.resolve is True:
             self.resolve = True
         if args.output_format is not None:
+            self.action_output_format = args.output_format
             self.output_format = args.output_format
         if args.roles is not None:
             self.roles = [role.strip() for role in args.roles.split(',') if role.strip()]
@@ -272,7 +274,9 @@ class Config(object):
         config_dict['aws_default_duration'] = self._get_aws_default_duration(defaults['aws_default_duration'])
         config_dict['preferred_mfa_type'] = self._get_preferred_mfa_type(defaults['preferred_mfa_type'])
         config_dict['remember_device'] = self._get_remember_device(defaults['remember_device'])
-        config_dict['output_format'] = self._get_output_format(defaults['output_format'])
+        config_dict["output_format"] = ''
+        if not config_dict["write_aws_creds"]:
+            config_dict['output_format'] = self._get_output_format(defaults['output_format'])
 
         # If write_aws_creds is True get the profile name
         if config_dict['write_aws_creds'] is True:

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -195,6 +195,8 @@ class Config(object):
                 profile_config = dict(config[self.conf_profile])
                 return self._handle_config(config, profile_config, include_inherits)
             except KeyError:
+                if self.action_configure:
+                    return {}
                 raise errors.GimmeAWSCredsError(
                     'Configuration profile not found! Use the --action-configure flag to generate the profile.')
         raise errors.GimmeAWSCredsError('Configuration file not found! Use the --action-configure flag to generate file.')

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -791,8 +791,16 @@ class GimmeAWSCreds(object):
         self.handle_action_list_profiles()
         self.handle_action_store_json_creds()
         self.handle_action_list_roles()
-
+        
+        # for each data item, if we have an override on output, prioritize that
+        # if we do not, prioritize writing credentials to file if that is in our
+        # configuration. If we are not writing to a credentials file, use whatever
+        # is in the output format field (default to exports)
         for data in self.iter_selected_aws_credentials():
+            if self.config.action_output_format:
+                self.write_result_action(self.config.action_output_format, data)
+                continue
+
             write_aws_creds = str(self.conf_dict['write_aws_creds']) == 'True'
             # check if write_aws_creds is true if so
             # get the profile name and write out the file
@@ -800,18 +808,26 @@ class GimmeAWSCreds(object):
                 self.write_aws_creds_from_data(data)
                 continue
 
-            if self.output_format == 'json':
-                self.ui.result(json.dumps(data))
-                continue
-
-            # Defaults to `export` format
-            self.ui.result("export AWS_ROLE_ARN=" + data['role']['arn'])
-            self.ui.result("export AWS_ACCESS_KEY_ID=" + data['credentials']['aws_access_key_id'])
-            self.ui.result("export AWS_SECRET_ACCESS_KEY=" + data['credentials']['aws_secret_access_key'])
-            self.ui.result("export AWS_SESSION_TOKEN=" + data['credentials']['aws_session_token'])
-            self.ui.result("export AWS_SECURITY_TOKEN=" + data['credentials']['aws_security_token'])
+            self.write_result_action(self.conf_dict["output_format"], data)
 
         self.config.clean_up()
+
+    def write_result_action(self, action, data):
+        if action == "json":
+            self.ui.result(json.dumps(data))
+            return
+        else:
+            # Defaults to `export` format
+            self.ui.result("export AWS_ROLE_ARN=" + data['role']['arn'])
+            self.ui.result("export AWS_ACCESS_KEY_ID=" +
+                           data['credentials']['aws_access_key_id'])
+            self.ui.result("export AWS_SECRET_ACCESS_KEY=" +
+                           data['credentials']['aws_secret_access_key'])
+            self.ui.result("export AWS_SESSION_TOKEN=" +
+                           data['credentials']['aws_session_token'])
+            self.ui.result("export AWS_SECURITY_TOKEN=" +
+                           data['credentials']['aws_security_token'])
+
 
     def handle_action_configure(self):
         # Create/Update config when configure arg set


### PR DESCRIPTION
https://github.com/Nike-Inc/gimme-aws-creds/issues/238
Issue #238 
Issue #236 

## Description
There is a strong preference set for "write to credentials file". If that is set in your config currently, then that overrides everything. This switches it so that the priority is thus:
1. parameters sent into run (-o json)
2. configured to write to credentials file
3. configuration in config that says json or export if configuration to write is False

Also, there is an issue with creating new profiles in 2.3.4. It errors out on configuring a new profile because we are trying to get the configuration of the profile before it is created. This checks to see when we are trying to get a profile if we are doing an action-configure and, if so, doesn't raise an error before trying to create it.

## Related Issue
https://github.com/Nike-Inc/gimme-aws-creds/issues/238
https://github.com/Nike-Inc/gimme-aws-creds/issues/236

## Motivation and Context
Fixes output_format results
Fixes profile creation 

## How Has This Been Tested?
Tested it by walking through various configurations and validating that it performed as expected for:
* with write_to_aws set 
** with no params
** with json and export
* with write_to_aws not set
** with no params
** with params

Ran all unit tests

and tested setting those parameters as well.
Tested this in a virtual environment on pycharm.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
