### PR TITLE
Checks for `python` without `3`

### DIFF
--- a/bin/gimme-aws-creds.cmd
+++ b/bin/gimme-aws-creds.cmd
@@ -16,6 +16,11 @@ for /f "tokens=2 delims==" %%i in ('assoc .py') do (
         )
     )
 )
+for %%i in (cmd bat exe) do (
+    for %%j in (python.%%i) do (
+        call :SetPythonExe "%%~$PATH:j"
+    )
+)
 %PythonExe% -x %PythonExeFlags% "%~f0" %*
 exit /B %ERRORLEVEL%
 goto :EOF


### PR DESCRIPTION
Sometimes Python 3 for Windows ends up as `python.exe` instead of `python3.exe`. This change allows the .cmd file to find it.

## Related Issue
https://github.com/Nike-Inc/gimme-aws-creds/issues/257

## Motivation and Context
We couldn't get gimme to run on Windows without it in one case.

## How Has This Been Tested?
Tested a very similar change on my colleague's workstation that wouldn't work without it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
