### PR TITLE
Expose expiration timestamp

### DIFF
--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -169,7 +169,7 @@ class Config(object):
 
     def _handle_config(self, config, profile_config, include_inherits = True):
         if "inherits" in profile_config.keys() and include_inherits:
-            print("Using inherited config: " + profile_config["inherits"])
+            self.ui.message("Using inherited config: " + profile_config["inherits"])
             if profile_config["inherits"] not in config:
                 raise errors.GimmeAWSCredsError(self.conf_profile + " inherits from " + profile_config["inherits"] + ", but could not find " + profile_config["inherits"])
             combined_config = {

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -742,6 +742,7 @@ class GimmeAWSCreds(object):
                 'aws_secret_access_key': aws_creds.get('SecretAccessKey', ''),
                 'aws_session_token': aws_creds.get('SessionToken', ''),
                 'aws_security_token': aws_creds.get('SessionToken', ''),
+                'expiration': aws_creds.get('Expiration').isoformat(),
             } if bool(aws_creds) else {}
         }
 


### PR DESCRIPTION
Adds `expiration` to the JSON output for temporary credentials.

## Related Issue

https://github.com/Nike-Inc/gimme-aws-creds/issues/259

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

I didn't find any unit tests for JSON output. Lmk if you'd like me to add one.
All existing tests pass. Tested my change by running the following command:

```
gimme-aws-creds --profile my-profile --output-format json
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

I could not sign a CLA, the link in [CONTRIBUTING.md](https://github.com/Nike-Inc/gimme-aws-creds/blob/c91842b69aa705340875527a4da548f4d4329936/CONTRIBUTING.md) doesn't work.
