### PR TITLE
Added function with feedback when DEFAULT profile does not exist

### DIFF
--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -191,6 +191,7 @@ class Config(object):
 
             try:
                 profile_config = dict(config[self.conf_profile])
+                self.fail_if_profile_not_found(profile_config, self.conf_profile, config.default_section)
                 return self._handle_config(config, profile_config, include_inherits)
             except KeyError:
                 raise errors.GimmeAWSCredsError(
@@ -555,3 +556,14 @@ class Config(object):
         """ clean up secret stuff"""
         del self.username
         del self.api_key
+
+    def fail_if_profile_not_found(self, profile_config, conf_profile, default_section):
+        """
+        When a users profile does not have a profile named 'DEFAULT' configparser fails to throw
+        an exception. This will raise an exception that handles this case and provide better messaging
+        to the user why the failure occurred.
+        Ensure that whichever profile is set as the default exists in the end users okta config
+        """
+        if not profile_config and conf_profile == default_section:
+            raise errors.GimmeAWSCredsError(
+                'DEFAULT profile is missing! This is profile is required when not using --profile')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ import tempfile
 from mock import patch
 from nose.tools import assert_equals
 
-from gimme_aws_creds import ui
+from gimme_aws_creds import ui, errors
 from gimme_aws_creds.config import Config
 
 
@@ -112,6 +112,21 @@ aws_rolename = myrole
             "aws_appname": "baz",
             "aws_rolename": "myrole",
         })
+
+    def test_fail_if_profile_not_found(self):
+        """Test to make sure missing Default fails properly"""
+        test_ui = MockUserInterface(argv=[])
+        with open(test_ui.HOME + "/.okta_aws_login_config", "w") as config_file:
+            config_file.write("""
+        [myprofile]
+        client_id = foo
+        """)
+        config = Config(gac_ui=test_ui, create_config=False)
+        config.conf_profile = "DEFAULT"
+        with self.assertRaises(errors.GimmeAWSCredsError) as context:
+            config.get_config_dict()
+        self.assertTrue('DEFAULT profile is missing! This is profile is required when not using --profile' == context.exception.message)
+
 
 class MockUserInterface(ui.UserInterface):
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Created a function that verifies that the profile_config contains data before continuing, if not it will raise an exception detailing why it failed
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Nike-Inc/gimme-aws-creds/issues/265

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Provides better feedback to end users with customized configs that may have removed or renamed the [DEFAULT] profile, which can cause unexpected behavior
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. modified config to not contain [DEFAULT] profile (replaced with parent)
2. ran gimme-aws-creds --action-list-profiles
3. received new error
4. ran gimme-aws-creds --action-list-profiles -p fake
5. received 'Configuration profile not found! Use the --action-configure flag to generate the profile.'
6. ran gimme-aws-creds --action-list-profiles -p parent
7. recieved list of profiles
8. created and ran unitTest test_fail_if_profile_not_found, which passed


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. (not sure, might be good to call out that 'DEFAULT' is a required profile)
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
