### PR TITLE
Restrict fido2 latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ beautifulsoup4>=4.6.0,<5.0.0
 configparser>=3.5.0,<4.0.0
 keyring>=10.4.0
 requests>=2.13.0,<3.0.0
-fido2>=0.8.0,<=0.9.0
+fido2>=0.8.0,<0.9.0
 okta>=0.0.4,<1.0.0


### PR DESCRIPTION
## Description
`fido2` released [version 0.9.0](https://github.com/Yubico/python-fido2/releases/tag/0.9.0) with breaking changes, which broke `gimme-aws-creds`.

## Related Issue
Fix #275.

## Motivation and Context
PR #215 should have restricted the latest `fido2` version with `<` instead of `<=`.

## How Has This Been Tested?
This was tested with an internal wrapper library. The change proposed in this PR is just a subset of the already merged PR #215.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
