### PR TITLE
Pin cryptography to version that avoids setuptools_rust error, fix #279

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ keyring>=10.4.0
 requests>=2.13.0,<3.0.0
 fido2>=0.8.0,<0.9.0
 okta>=0.0.4,<1.0.0
+cryptography==3.3.2


### PR DESCRIPTION

## Description
adds cryptography module to requirements.txt pinned to version 3.3.2

## Related Issue
#279

## Motivation and Context
Fixes above issue

## How Has This Been Tested?
Ran `docker build .` with change in place, and it succeeded.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
