### PR TITLE
Bumped dependencies + ctap keyring device fixes

### DIFF
--- a/gimme_aws_creds/errors.py
+++ b/gimme_aws_creds/errors.py
@@ -61,6 +61,11 @@ class GimmeAWSCredsError(GimmeAWSCredsExceptionBase, GimmeAWSCredsExitError):
     pass
 
 
+class GimmeAWSCredsMFAEnrollStatus(GimmeAWSCredsError):
+    def __init__(self):
+        super().__init__("You must enroll in MFA before using this tool.", 2)
+
+
 class NoFIDODeviceFoundError(Exception):
     pass
 
@@ -71,4 +76,3 @@ class FIDODeviceTimeoutError(Exception):
 
 class FIDODeviceError(Exception):
     pass
-

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -893,6 +893,7 @@ class GimmeAWSCreds(object):
             # noinspection PyStatementEffect
             self.auth_session
 
+            self.okta.set_preferred_mfa_type(None)
             credential_id, user = self.okta.setup_fido_authenticator()
 
             registered_authenticators = RegisteredAuthenticators(self.ui)

--- a/gimme_aws_creds/u2f.py
+++ b/gimme_aws_creds/u2f.py
@@ -18,7 +18,7 @@ from threading import Event, Thread
 
 from fido2.ctap1 import APDU
 from fido2.ctap1 import ApduError
-from fido2.ctap1 import CTAP1
+from fido2.ctap1 import Ctap1
 from fido2.hid import CtapHidDevice
 from fido2.utils import sha256, websafe_decode
 
@@ -55,7 +55,7 @@ class FactorU2F(object):
             self.ui.info("No FIDO device found")
             raise NoFIDODeviceFoundError
 
-        self._clients = [CTAP1(d) for d in devs]
+        self._clients = [Ctap1(d) for d in devs]
 
     def work(self, client):
         for _ in range(30):

--- a/gimme_aws_creds/webauthn.py
+++ b/gimme_aws_creds/webauthn.py
@@ -76,9 +76,10 @@ class WebAuthnClient(object):
 
     def _verify(self, client):
         try:
+            user_verification = self._get_user_verification_requirement_from_client(client)
             options = PublicKeyCredentialRequestOptions(challenge=self._challenge, rp_id=self._rp['id'],
                                                         allow_credentials=self._allow_list, timeout=self._timeout_ms,
-                                                        user_verification=UserVerificationRequirement.PREFERRED)
+                                                        user_verification=user_verification)
 
             pin = self._get_pin_from_client(client)
             assertion_selection = client.get_assertion(options, event=self._event,
@@ -147,3 +148,10 @@ class WebAuthnClient(object):
         # Prompt for PIN if needed
         pin = getpass("Please enter PIN: ")
         return pin
+
+    @staticmethod
+    def _get_user_verification_requirement_from_client(client):
+        if not client.info.options.get(CtapOptions.USER_VERIFICATION):
+            return None
+
+        return UserVerificationRequirement.PREFERRED

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ beautifulsoup4>=4.6.0,<5.0.0
 configparser>=3.5.0,<4.0.0
 keyring>=21.4.0
 requests>=2.13.0,<3.0.0
-fido2>=0.8.1,<=0.9.0
+fido2>=0.9.1,<1.0.0
 okta>=0.0.4,<1.0.0
-ctap-keyring-device>=1.0.4
+ctap-keyring-device>=1.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ beautifulsoup4>=4.6.0,<5.0.0
 configparser>=3.5.0,<4.0.0
 keyring>=21.4.0
 requests>=2.13.0,<3.0.0
-fido2>=0.9.1,<1.0.0
+fido2>=0.9.1,<0.10.0
 okta>=0.0.4,<1.0.0
 ctap-keyring-device>=1.0.6


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Bumped the fido2 & ctap-keyring-device libraries
- Fixed webauthn device flow when using fido2>=0.9.0 (was broken due to breaking changes introduced to the fido2 library in 0.9.0)
- Fixed the fido authentication setup flow in cases okta returns an MFA_ENROLL status (expected if this is the first time registering a new authenticator over a period of time)
- Fixed the webauthn flow for ctap devices which do not support user verification (passing the uv-preferred flag in that case fails the request)

Per-file changes:

errors.py
- Added GimmeAWSCredsMFAEnrollStatus

okta.py
- GimmeAWSCredsMFAEnrollStatus is now raised when step-up auth status is MFA_ENROLL
- Fixed fido authenticator registration in cases where stepup_auth returns MFA_ENROLL (normal in this scenario)

requirements.txt
- Bumped fido2 to 0.9.1
- Bumped ctap-keyring-device to 1.0.6 (fido2 bump, fixed for breaking changes)

u2f.py
- Migrated from CTAP1 to Ctap1 (all-caps is to be deprecated in the future)

webauthn.py
- Fixed get-assertion & make-credential flow with new fido2 returned data types
- Will now only pass the user verification flag if the ctap device supports it


main.py
- Will now reset the preferred mfa type when registering a fido authenticator; 
this is due to the fact that a user might have webauthn as a preferred type - the ctap keyring device might fail with existing webauthn devices 

## Related Issue
https://github.com/Nike-Inc/gimme-aws-creds/issues/284

## Motivation and Context
2.4.0 Introduced a ctap-keyring-device, which is a virtual FIDO authenticator based on touch-id / WinCred / other keyring backends.

When the initial version of ctap-keyring-device used alongside fido2>=0.9.0, some breaking changes in the fido
library took a toll and raised an exception.

## How Has This Been Tested?
- Tested against a HID device
- Tested against a virtual (Touch ID device)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [-] My change requires a change to the documentation.
- [-] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [-] I have added tests to cover my changes.
- [X] All new and existing tests passed.
