### PR TITLE
Fix ctap_keyring_device dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ beautifulsoup4>=4.6.0,<5.0.0
 configparser>=3.5.0,<4.0.0
 keyring>=21.4.0
 requests>=2.13.0,<3.0.0
-fido2>=0.8.1,<=0.9.0
+fido2>=0.8.1,<=0.9.1
 okta>=0.0.4,<1.0.0
 ctap-keyring-device>=1.0.4


### PR DESCRIPTION
The latest versions break with fido2 0.9.0

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue

#286

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

I've tested the new dependency with pipx:

```
pipx install gimme-aws-creds
﻿﻿pipx inject gimme-aws-creds ctap-keyring-device==1.0.6
```

After injecting the dependency with the proper transitive dependencies, the issue went away (and another issue was revealed with adding a fido device).

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
