### PR TITLE
manually install futures to avoid setup.py failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV PACKAGES="gcc musl-dev python3-dev libffi-dev openssl-dev cargo"
 
 RUN apk --update add $PACKAGES \
     && pip install --upgrade pip setuptools-rust \
+    && pip install futures \
     && python setup.py install \
     && apk del --purge $PACKAGES
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Manually installing `futures` as a separate step before running `setup.py install` avoids the Docker build error described in the issue

## Related Issue
#290 

## Motivation and Context
Permits docker build to succeed

## How Has This Been Tested?
`docker build` and `make test` succeed

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
