### PR TITLE
added support for question factor_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ A configuration wizard will prompt you to enter the necessary configuration para
   - sms - OTP via SMS message
   - web - DUO uses localhost webbrowser to support push|call|passcode
   - passcode - DUO uses `OKTA_MFA_CODE` or `--mfa-code` if set, or prompts user for passcode(OTP).
+  - question - Secret to the security question
   
 - resolve_aws_alias - y or n. If yes, gimme-aws-creds will try to resolve AWS account ids with respective alias names (default: n). This option can also be set interactively in the command line using `-r` or `--resolve` parameter
 - include_path - (optional) Includes full role path to the role name in AWS credential profile name. (default: n).  If `y`: `<acct>-/some/path/administrator`. If `n`: `<acct>-administrator`

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -566,6 +566,25 @@ class OktaClient(object):
             return self._login_input_webauthn_challenge(state_token, factor)
         elif factor['factorType'] == 'token:hardware':
             return self._login_input_mfa_challenge(state_token, factor['_links']['verify']['href'])
+        elif factor['factorType'] == 'question':
+            return self._login_input_question(state_token, factor)
+
+    def _login_input_question(self, state_token, factor):
+        answer = self.ui.input("Enter secret answer: ", hidden=True)
+        response = self._http_client.post(
+            factor['_links']['verify']['href'],
+            params={'rememberDevice': self._remember_device},
+            json={'stateToken': state_token, 'answer': answer},
+            headers=self._get_headers(),
+            verify=self._verify_ssl_certs
+        )
+        response.raise_for_status()
+        response_data = response.json()
+
+        if 'stateToken' in response_data:
+            return {'stateToken': response_data['stateToken'], 'apiResponse': response_data}
+        if 'sessionToken' in response_data:
+            return {'stateToken': None, 'sessionToken': response_data['sessionToken'], 'apiResponse': response_data}
 
     def _login_input_mfa_challenge(self, state_token, next_url):
         """ Submit verification code for SMS or TOTP authentication methods"""
@@ -853,6 +872,8 @@ class OktaClient(object):
             return factor['factorType'] + ": " + factor_name
         elif factor['factorType'] == 'token:hardware':
             return factor['factorType'] + ": " + factor['provider']
+        elif factor['factorType'] == 'question':
+            return factor['factorType']
 
         else:
             return "Unknown MFA type: " + factor['factorType']


### PR DESCRIPTION
Adds support to the question factor that Okta provides

## Description
Adds support to question factor type in Okta. Helps to authorise users who only have question factor assigned.

## Related Issue
Support for question factor type #297

## Motivation and Context
This change was required to enable users logging into aws, when they had only factor_type question assigned to them.

## How Has This Been Tested?
The change was made only to okta.py, and tested by connecting to a live aws env.

## Screenshots (if appropriate):

![Screenshot 2021-05-07 at 21 10 44](https://user-images.githubusercontent.com/30045460/117475069-4183ea80-af79-11eb-91a7-a013c17b2485.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
