### PR TITLE
Save token expiration time in AWS credentials file

### DIFF
--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -114,7 +114,7 @@ class GimmeAWSCreds(object):
         self._cache = {}
 
     #  this is modified code from https://github.com/nimbusscale/okta_aws_login
-    def _write_aws_creds(self, profile, access_key, secret_key, token, aws_config=None):
+    def _write_aws_creds(self, profile, access_key, secret_key, token, expiration=None, aws_config=None):
         """ Writes the AWS STS token into the AWS credential file"""
         # Check to see if the aws creds path exists, if not create it
         aws_config = aws_config or self.AWS_CONFIG
@@ -138,6 +138,8 @@ class GimmeAWSCreds(object):
         config.set(profile, 'aws_secret_access_key', secret_key)
         config.set(profile, 'aws_session_token', token)
         config.set(profile, 'aws_security_token', token)
+        if expiration is not None:
+            config.set(profile, 'expiration', expiration)
 
         # Write the updated config file
         with open(aws_config, 'w+') as configfile:
@@ -146,7 +148,7 @@ class GimmeAWSCreds(object):
         os.chmod(aws_config, 0o600)
         self.ui.result('Written profile {} to {}'.format(profile, aws_config))
 
-    def write_aws_creds_from_data(self, data, aws_config=None):
+    def write_aws_creds_from_data(self, data, aws_config=None, save_expiration=False):
         if not isinstance(data, dict):
             self.ui.warning('json line is not a dict! ' + repr(data))
             return
@@ -187,6 +189,7 @@ class GimmeAWSCreds(object):
             credentials['aws_access_key_id'],
             credentials['aws_secret_access_key'],
             credentials['aws_session_token'],
+            credentials['expiration'] if save_expiration else None,
             aws_config=aws_config,
         )
 

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -745,7 +745,7 @@ class GimmeAWSCreds(object):
                 'aws_access_key_id': aws_creds.get('AccessKeyId', ''),
                 'aws_secret_access_key': aws_creds.get('SecretAccessKey', ''),
                 'aws_session_token': aws_creds.get('SessionToken', ''),
-                'aws_security_token': aws_creds.get('SessionToken', ''),
+                'aws_security_token': aws_creds.get('SessionToken', ''),  # deprecated (https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/)
                 'expiration': aws_creds.get('Expiration').isoformat(),
             } if bool(aws_creds) else {}
         }


### PR DESCRIPTION
## Description

Instead of running `aws sts get-caller-identity` to check if the token is valid (because [no permissions are required for this command](https://docs.aws.amazon.com/cli/latest/reference/sts/get-caller-identity.html#description)), or any other command that tries to use the AWS credentials, it would be better to check for the expiration time directly. Therefore, having it in a file seems appropriate.

[According to AWS](url):

> You can store only a subset of settings and values in the `credentials` file. Generally, it's only those with values that would be considered "secrets" or sensitive, such as access key IDs and secret keys. The page for each setting in this guide states whether it can be stored in the `credentials` file or if it can be stored only in the `config` file.

And the list they refer to is [here](https://docs.aws.amazon.com/sdkref/latest/guide/settings-global.html).

Since the value of `expiration` is not secret, if we follow the advice above, it should be saved in the `config` file. But it's a custom field not listed in the table in the link above, and I believe it makes more sense to write it in the `credentials` file, together with the corresponding credentials. Besides, the modification I had to make in this code was very simple to make it happen.

Lastly, another modification in the code was the added comment about the AWS security token. Based on [this answer](https://stackoverflow.com/a/58759340/7649076) and on the AWS blog post linked in the comment, the AWS security token is not used anymore, and it seems relevant to add a comment, so that users avoid using it.

## Related Issue

I didn't open an issue, because it was simple modification, and I wanted to check if it made sense and if it worked. The discussion can be made in this PR.

## Motivation and Context

The token expiration time was exposed in PR #260, but it is not saved in the credentials file. I'm proposing this new behavior, which is backwards compatible.

## How Has This Been Tested?

Getting the credentials and expiration time:

```python
from gimme_aws_creds.main import GimmeAWSCreds
from gimme_aws_creds.ui import CLIUserInterface

ui = CLIUserInterface()
aws_creds = GimmeAWSCreds(ui=ui)

for data in aws_creds.iter_selected_aws_credentials():
    profile_name = data['profile']['name']
    data['profile']['name'] = 'with-expiration-' + profile_name
    aws_creds.write_aws_creds_from_data(data, save_expiration=True)
    data['profile']['name'] = 'without-expiration-' + profile_name
    aws_creds.write_aws_creds_from_data(data)
```

Testing:

```bash
$ aws configure get expiration --profile without-expiration-<profile-name>

$ echo $?
1

$ aws configure get expiration --profile with-expiration-<profile-name>
2021-06-13T07:38:48+00:00

$ echo $?
0

$ aws s3 ls --profile with-expiration-<profile-name>
[the list of buckets was shown]

$ aws s3 ls --profile without-expiration-<profile-name>
[the list of buckets was shown]
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
