### PR TITLE
Feat filter selection: adds --filter-selection/-f option to filter generated role selection screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ You can run a specific configuration profile with the `--profile` parameter:
 
 The username and password you are prompted for are the ones you login to Okta with. You can predefine your username by setting the `OKTA_USERNAME` environment variable or using the `-u username` parameter.
 
-If you have not configured an Okta App or Role, you will prompted to select one.
+If you have not configured an Okta App or Role, you will prompted to select one. If you want to filter the resulting list (for those will access to hundreds of roles), you can make use of the `--filter-selection/-f` option like so: `gimme-aws-creds -f prod` which would return only the roles where the account name starts with prod. Note: use of the `-f` option requires `resolve_aws_alias` to be set to `True` to work properly.
 
 If all goes well you will get your temporary AWS access, secret key and token, these will either be written to stdout or `~/.aws/credentials`.
 

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -55,6 +55,7 @@ class Config(object):
         self.action_output_format = False
         self.output_format = 'export'
         self.roles = []
+        self.filter_selection = ""
 
         if self.ui.environ.get("OKTA_USERNAME") is not None:
             self.username = self.ui.environ.get("OKTA_USERNAME")
@@ -105,6 +106,15 @@ class Config(object):
                  'can be regex in format /<pattern>/. '
                  'for example: arn:aws:iam::123456789012:role/Admin,/:210987654321:/ '
                  'would match both account 123456789012 by ARN and 210987654321 by regexp'
+        )
+        parser.add_argument(
+            '--filter-selection', '-f',
+            help='If set, the input will be used to filter the list of roles presented to the user. '
+                 'The filter acts on the so called \'friendly_account_name\' associated with each role. '
+                 'The friendly account name contains the account name and number. '
+                 'For example: \'nonprod\' would match any roles where the text \'nonprod\' is found. '
+                 'If only one match is found, it will be auto selected and credentials generated. '
+                 'If no results are found, the program exits.'
         )
         parser.add_argument(
             '--resolve', '-r',
@@ -173,6 +183,8 @@ class Config(object):
             self.output_format = args.output_format
         if args.roles is not None:
             self.roles = [role.strip() for role in args.roles.split(',') if role.strip()]
+        if args.filter_selection is not None:
+            self.filter_selection = args.filter_selection.strip()
         self.conf_profile = args.profile or 'DEFAULT'
 
     def _handle_config(self, config, profile_config, include_inherits = True):

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -372,7 +372,7 @@ class GimmeAWSCreds(object):
 
         return selection
 
-    def _get_selected_roles(self, requested_roles, aws_roles):
+    def _get_selected_roles(self, requested_roles, aws_roles, filter_selection=None):
         """ select the role from the config file if it exists in the
         results from Okta.  If not, present the user with a menu. """
         # 'all' is a special case - skip processing
@@ -399,6 +399,10 @@ class GimmeAWSCreds(object):
                 return ret
             self.ui.error("ERROR: AWS roles [{}] not found!".format(', '.join(requested_roles)))
 
+        if filter_selection:
+            filtered_roles = [role for role in aws_roles if filter_selection in role.friendly_account_name]
+            return self._choose_roles(filtered_roles)
+        
         # Present the user with a list of roles to choose from
         return self._choose_roles(aws_roles)
 
@@ -669,7 +673,7 @@ class GimmeAWSCreds(object):
     def aws_selected_roles(self):
         if 'aws_selected_roles' in self._cache:
             return self._cache['aws_selected_roles']
-        selected_roles = self._get_selected_roles(self.requested_roles, self.aws_roles)
+        selected_roles = self._get_selected_roles(self.requested_roles, self.aws_roles, self.config.filter_selection)
         self._cache['aws_selected_roles'] = ret = [
             role
             for role in self.aws_roles

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,6 +31,7 @@ class TestConfig(unittest.TestCase):
             remember_device=False,
             output_format=None,
             roles=None,
+            filter_selection = None,
             action_register_device=False,
             action_configure=False,
             action_list_profiles=False,


### PR DESCRIPTION
## Description
This option will filter out the list of roles generated when called `gimme-aws-creds` to show only those that contain a match on the passed in string.

Example: `gimme-aws-creds` might return:
[ 1 ] myaccount-poc-Roleone
[ 2 ] myaccount-dev1-Roleone
[ 3 ] myaccount-dev2-Roleone
[ 4 ] myaccount-prod-Roleone

And `gimme-aws-creds -f dev` would return:
[ 1 ] myaccount-dev1-Roleone
[ 2 ] myaccount-dev2-Roleone

If only one match is found, it is auto selected (already the default behavior - not part of this feature).

## Related Issue
None

## Motivation and Context
This change is helpful for users with access to many roles. For instance, my team at WarnerBros has access to hundreds of roles across hundreds of AWS accounts, and selecting the one we need at a given time from a long list is tedious. This option let's us call the the specific account we need access to, or a part of it (the list of poc accounts, or dev accounts, or prod accounts), and select from a much smaller list.

## How Has This Been Tested?
This change was tested manually by running:
1. `gimme-aws-creds` by itself and verifying the resulting list.
2. `gimme-aws-creds -f poc` and verifying the resulting list, selecting one and verifying the resulting creds worked with an `aws --profile aws-aio-poc sts get-caller-identity` call.
3. `gimme-aws-creds -f aws-aio-poc` and verifying the generated creds worked with an `aws --profile aws-aio-poc sts get-caller-identity` call.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
