### PR TITLE
Add libgcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /opt/gimme-aws-creds
 
 COPY . .
 
+RUN apk --update add libgcc
+
 ENV PACKAGES="gcc musl-dev python3-dev libffi-dev openssl-dev cargo"
 
 RUN apk --update add $PACKAGES \


### PR DESCRIPTION
Fix missing dependency on libgcc

## Description
Adds missing run-time dependency for Python cryptography package.

## Related Issue
Fixes #321

## Motivation and Context
Currently the cryptography package will bring in libgcc as a dependency when built, resulting in the following error on first run:

```
ImportError: Error loading shared library libgcc_s.so.1: No such file or directory
```

## How Has This Been Tested?
```
$ docker build -t gimme-aws-creds .
...
$ docker run --rm -ti gimme-aws-creds
No gimme-aws-creds configuration file found, starting first-time configuration...
...
```

i.e. attempting to run succeeds instead of the traceback shown in #321.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

The CLA-signing page is broken but consider it signed by my opening this PR.