### PR TITLE
MFA String Matching for more languages

### DIFF
--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -1059,8 +1059,6 @@ class OktaClient(object):
             '額外驗證'
         )
 
-        # print(saml_soup.title.string)
-        #if hasattr(saml_soup.title, 'string') and re.match(".* - (Extra Verification|Vérification supplémentaire|Zusätzliche Bestätigung)$", saml_soup.title.string):
         if hasattr(saml_soup.title, 'string') and saml_soup.title.string.endswith(mfa_string):
             # extract the stateToken from the Javascript code in the page and step up to MFA
             # noinspection PyTypeChecker

--- a/gimme_aws_creds/okta.py
+++ b/gimme_aws_creds/okta.py
@@ -1028,8 +1028,40 @@ class OktaClient(object):
     @staticmethod
     def _extract_state_token_from_http_response(http_res):
         saml_soup = BeautifulSoup(http_res.text, "html.parser")
+        
+        mfa_string = (
+            'Dodatečné ověření',
+            'Ekstra verificering',
+            'Zusätzliche Bestätigung',
+            'Πρόσθετη επαλήθευση',
+            'Extra Verification',
+            'Verificación adicional',
+            'Lisätodennus',
+            'Vérification supplémentaire',
+            'Extra ellenőrzés',
+            'Verifikasi Tambahan',
+            'Verifica aggiuntiva',
+            '追加認証',
+            '추가 확인',
+            'Penentusahan Tambahan',
+            'Ekstra verifisering',
+            'Extra verificatie',
+            'Dodatkowa weryfikacja',
+            'Verificação extra',
+            'Verificare suplimentară',
+            'Дополнительная проверка',
+            'Extra verifiering',
+            'การตรวจสอบพิเศษ',
+            'Ekstra Doğrulama',
+            'Додаткова верифікація',
+            'Xác minh bổ sung',
+            '额外验证',
+            '額外驗證'
+        )
 
-        if hasattr(saml_soup.title, 'string') and re.match(".* - (Extra Verification|Vérification supplémentaire)$", saml_soup.title.string):
+        # print(saml_soup.title.string)
+        #if hasattr(saml_soup.title, 'string') and re.match(".* - (Extra Verification|Vérification supplémentaire|Zusätzliche Bestätigung)$", saml_soup.title.string):
+        if hasattr(saml_soup.title, 'string') and saml_soup.title.string.endswith(mfa_string):
             # extract the stateToken from the Javascript code in the page and step up to MFA
             # noinspection PyTypeChecker
             state_token = decode(re.search(r"var stateToken = '(.*)';", http_res.text).group(1), "unicode-escape")


### PR DESCRIPTION
Match all? language specific strings for MFA verification

## Description
With this pull-request I created a tuple with all? language specific MFA extra verification strings

## Related Issue
Fixes #339 
Fixes #317 


## Motivation and Context
People with other language than "English" in Okta-Webfrontend get an error, because the regex match did not get, that mfa is needed

## How Has This Been Tested?
I tested it with several languages and it works for me

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
