### PR TITLE
Add optional cookiejar support to reduce password/MFA prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ A configuration wizard will prompt you to enter the necessary configuration para
   - The reserved word `acc-role` will use the name component of the role arn prepended with account number (or alias if `resolve_aws_alias` is set to y) to avoid collisions, i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [123456789012-okta-1234-role], or if `resolve_aws_alias` [<my alias>-okta-1234-role] in the aws credentials file
   - If set to `default` then the temp creds will be stored in the default profile
   - Note: if there are multiple roles, and `default` is selected it will be overwritten multiple times and last role wins. The same happens when `role` is selected and you have many accounts with the same role names. Consider using `acc-role` if this happens.
+- jar - This is optional. Path to read/store cookies containing Okta session cookies potentially reducing password/MFA prompts depending on your organization's policy configuration.
 - aws_appname - This is optional. The Okta AWS App name, which has the role you want to assume.
 - aws_rolename - This is optional. The ARN of the role you want temporary AWS credentials for.  The reserved word 'all' can be used to get and store credentials for every role the user is permissioned for.
 - aws_default_duration = This is optional. Lifetime for temporary credentials, in seconds. Defaults to 1 hour (3600)

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -146,10 +146,6 @@ class Config(object):
             '--action-setup-fido-authenticator', action='store_true',
             help='Sets up a new FIDO WebAuthn authenticator in Okta'
         )
-        parser.add_argument(
-            '--jar', '-j',
-            help='If set, the specified file will be used as a cookiejar.'
-        )
         args = parser.parse_args(self.ui.args)
 
         self.action_configure = args.action_configure
@@ -178,8 +174,6 @@ class Config(object):
             self.output_format = args.output_format
         if args.roles is not None:
             self.roles = [role.strip() for role in args.roles.split(',') if role.strip()]
-        if args.jar is not None:
-            self.jar = args.jar
         self.conf_profile = args.profile or 'DEFAULT'
 
     def _handle_config(self, config, profile_config, include_inherits = True):
@@ -255,6 +249,7 @@ class Config(object):
             'remember_device': 'n',
             'aws_default_duration': '3600',
             'device_token': '',
+            'jar': '',
             'output_format': 'export',
         }
 

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -41,6 +41,7 @@ class Config(object):
         self.api_key = None
         self.conf_profile = 'DEFAULT'
         self.verify_ssl_certs = True
+        self.jar = None
         self.app_url = None
         self.resolve = False
         self.mfa_code = None
@@ -145,6 +146,10 @@ class Config(object):
             '--action-setup-fido-authenticator', action='store_true',
             help='Sets up a new FIDO WebAuthn authenticator in Okta'
         )
+        parser.add_argument(
+            '--jar', '-j',
+            help='If set, the specified file will be used as a cookiejar.'
+        )
         args = parser.parse_args(self.ui.args)
 
         self.action_configure = args.action_configure
@@ -173,6 +178,8 @@ class Config(object):
             self.output_format = args.output_format
         if args.roles is not None:
             self.roles = [role.strip() for role in args.roles.split(',') if role.strip()]
+        if args.jar is not None:
+            self.jar = args.jar
         self.conf_profile = args.profile or 'DEFAULT'
 
     def _handle_config(self, config, profile_config, include_inherits = True):

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -41,7 +41,6 @@ class Config(object):
         self.api_key = None
         self.conf_profile = 'DEFAULT'
         self.verify_ssl_certs = True
-        self.jar = None
         self.app_url = None
         self.resolve = False
         self.mfa_code = None

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -536,7 +536,7 @@ class GimmeAWSCreds(object):
             self.okta_org_url,
             self.config.verify_ssl_certs,
             self.device_token,
-            self.config.jar
+            self.conf_dict.get('jar')
         )
 
         if self.config.username is not None:

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -536,6 +536,7 @@ class GimmeAWSCreds(object):
             self.okta_org_url,
             self.config.verify_ssl_certs,
             self.device_token,
+            self.config.jar
         )
 
         if self.config.username is not None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,7 +29,6 @@ class TestConfig(unittest.TestCase):
             resolve=None,
             mfa_code=None,
             remember_device=False,
-            jar=None,
             output_format=None,
             roles=None,
             action_register_device=False,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,7 @@ class TestConfig(unittest.TestCase):
             resolve=None,
             mfa_code=None,
             remember_device=False,
+            jar=None,
             output_format=None,
             roles=None,
             action_register_device=False,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,6 +32,7 @@ class TestConfig(unittest.TestCase):
             jar=None,
             output_format=None,
             roles=None,
+            jar=None,
             action_register_device=False,
             action_configure=False,
             action_list_profiles=False,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,7 +32,6 @@ class TestConfig(unittest.TestCase):
             jar=None,
             output_format=None,
             roles=None,
-            jar=None,
             action_register_device=False,
             action_configure=False,
             action_list_profiles=False,


### PR DESCRIPTION
## Description
Introduces an optional persistent [cookiejar](https://docs.python.org/3/library/http.cookiejar.html) to store/re-use Okta session cookies between executions of `gimme-aws-creds`. 

This will allow users who have multiple AWS tiles in the same Okta organization, or complex MFA polices in Okta to experience fewer MFA/password prompts.

## Related Issue
I didn't find any closely related issues, let me know if you'd like me to open one and focus the discussion on adding this functionality there instead of within a PR.

## Motivation and Context
Depending on the organization/application policy configured in Okta a user may only be required to authenticate every \<x\> minutes/hours to access okta and/or a specific application tile. 

Despite this policy, because `gimme-aws-creds` creates a new Okta session on each invocation (albeit with the same device token), the user will experience password/MFA prompts on each invocation of the CLI which does not match the behavior they would experience in a web browser accessing AWS.

## Implementation Details
To implement the change a custom [cookiejar](https://docs.python.org/3/library/http.cookiejar.html) class is added that extends from the existing [RequestsCookieJar](https://2.python-requests.org/en/master/api/#requests.cookies.RequestsCookieJar). This cookie jar uses the stdlib [http.cookiejar.LWPCookieJar](https://docs.python.org/3/library/http.cookiejar.html#http.cookiejar.LWPCookieJar) to serialize/deserialize the cookies (instead of the less secure [pickle](https://docs.python.org/3/library/pickle.html) option).

To avoid potential parallel invocations of `gimme-aws-creds` overwriting the jar file and corrupting it any writes to the jar are staged in a temporary file in the same directory, then renamed in place (replacing the previous jar) which is [an atomic operation](https://stackoverflow.com/questions/7054844/is-rename-atomic) within the same filesystem.

The jar is not very well optimized writing a file each time a cookie is created/deleted instead of batching changes but given the limited number of cookies/frequency of changes this seems like a reasonable trade-off for simplicity.
Alternatively [atexit](https://docs.python.org/3/library/atexit.html) could be used to flush the jar to disk when the CLI exits instead.

When `auth_session` is called and a cookie jar exists that contains a `sid` cookie, a call to [/api/v1/users/me](https://developer.okta.com/docs/reference/api/users/#get-current-user) is made to check if the session is still valid. If it is, the function returns early otherwise it will fall-through to the previous implementation generating a new session.

I also cleaned up/unified some of the request logic as part of this change:
* Moved `verify` and `headers` to be set on the [requests.Session](https://2.python-requests.org/en/master/api/#requests.Session) instead of every method call.
* Fixed cookie lookups to only match the okta organization/domain in use which is important now that a cookiejar could contain multiple domains.

I will also note there are potential security implications of storing okta sessions on disk without encryption (ex: Chrome uses the system keychain to store an encryption key). However this has little value for a Python CLI since the entire python binary will be allowed access to the key, not a specific script. Additionally this is a similar risk to writing AWS credentials to disk which the tool already does. Given this is a non-default option I think this is a reasonable trade-off. 

## How Has This Been Tested?
* CLI still works as expected (prompting every-time) when no cookiejar is configured.
* CLI works as expected when cookiejar is configured but not present
* CLI does not re-authentication if valid session cookies are present in the jar

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
