### PR TITLE
Unpin python-dateutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 boto3>=1.7.70,<2.0.0
-python-dateutil<=2.8.1
 beautifulsoup4>=4.6.0,<5.0.0
 configparser>=3.5.0,<4.0.0
 keyring>=21.4.0


### PR DESCRIPTION
## Description
Unpins a restrictive upper dependency bound

## Related Issue
Fixes  #313

## Motivation and Context
Since there‘s no explanation why your `python-dateutil` requirement is pinned, I’m going to assume it’s no longer an issue.

Upper bounds are bad if not absolutely necessary: https://iscinumpy.dev/post/bound-version-constraints/

## How Has This Been Tested?
I’m going to rely on your CI
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- N/A I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- N/A I have added tests to cover my changes.
- [x] All new and existing tests passed.
