### PR TITLE
Fido2 v1.0.0 pre-upgrade - pin ctap-keyring-device

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ keyring>=21.4.0
 requests>=2.13.0,<3.0.0
 fido2>=0.9.1,<0.10.0
 okta>=0.0.4,<1.0.0
-ctap-keyring-device>=1.0.6
+ctap-keyring-device==1.0.6


### PR DESCRIPTION
This commit pins ctap-keyring-device to 1.0.6, before I'm release a new tag 
that upgrade to fido2 v1.0.0, which contains breaking changes.

<!--- Provide a general summary of your changes in the Title above -->

## Description
ctap-keyring-device v2.0.0 would require fido2 v1.0.0, which has numerous breaking changes
that would affect gimme-aws-creds.
As this project is the biggest user of said library, I'd like to take this precaution to prevent breaking it for new installations.

Once pinned, I'll create a new tag from:
https://github.com/dany74q/ctap-keyring-device/pull/9

Then I'll create a separate PR here which bumps the pinned versions
of fido2 and ctap-keyring-device, along w/ fixing all breaking changes.

<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Nike-Inc/gimme-aws-creds/issues/355

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The new fido2 v1.0.0 release has several breaking changes that needs to be addressed;
Also, currently ctap-keyring-device uses the forsaken winrt module - in the new tag I'll migrate to
the community based winsdk, which support Python >= 3.10.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
$> pip install --editable .

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
