### PR TITLE
This corrects an issue with the validation of the org url and app url…

### DIFF
--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -320,7 +320,7 @@ class Config(object):
                 "okta-emea.com",
             ]
 
-            if url_parse_results.scheme == "https" and okta_org_url in allowlist:
+            if url_parse_results.scheme == "https" and any(urlelement in url_parse_results.hostname for urlelement in allowlist):
                 okta_org_url_valid = True
             else:
                 ui.default.error(
@@ -366,7 +366,7 @@ class Config(object):
                 "okta-emea.com",
             ]
 
-            if url_parse_results.scheme == "https" and app_url in allowlist:
+            if url_parse_results.scheme == "https" and any(urlelement in url_parse_results.hostname for urlelement in allowlist):
                 okta_org_url_valid = True
             else:
                 ui.default.warning(


### PR DESCRIPTION
… when using action-configure

This is correcting the logic that is used in the config.py file to validate if the url contains one of the valid okta domains.

## Description
The updated code will not correctly validated that the url provided by the user for the okta org or the app url will contain one of the elements contained in the allowlist. The validation logic that is in the code will always return false.

## Related Issue
bug fix discussed in https://github.com/Nike-Inc/gimme-aws-creds/issues/374

## Motivation and Context
We currently utilize the --action-configure feature for our employees to properly configure gimme-aws-creds for the first time utilization. We can provide a work around, but would prefer to utilize the functionality provided by the project already.

## How Has This Been Tested?
I was able to test with mutliple urls, both those that contain the one of the domains in the allow list and urls that do not contain those domains. The logic is now returning a proper true or false using the desired validation criteria. 

## Screenshots (if appropriate):

![valdationscreenhot](https://user-images.githubusercontent.com/72185584/205104240-63617aaa-056c-4e15-a0f8-5270745ce27a.jpeg)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
