### PR TITLE
Skip auth_session with gimme_creds_lambda and Okta Classic

### DIFF
--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -679,6 +679,10 @@ class GimmeAWSCreds(object):
                     id_token=False,
                     scopes=['openid']
                 )
+                
+                # auth_session isn't needed when using gimme_creds_lambda and Okta classic
+                self.set_auth_session(None)
+                
             elif self.okta_platform == 'identity_engine':
                 auth_result = self.auth_session
 


### PR DESCRIPTION

## Description
When using the gimme_creds_lambda and Okta Classic, the auth process was called twice (once in OktaClassic.auth_oauth() and again in OktaClassic.auth_session()).  The call to auth_session() is not necessary with Okta Classic.

## Motivation and Context
Users were challenged for credentials twice when using gimme-aws-creds

## How Has This Been Tested?
Verified on an Okta Classic and OIE domain

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ X] All new and existing tests passed.
