### PR TITLE
feat: add email option for mfa

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ To make it easier you can also create an alias for the gimme-aws-creds command w
 ```bash
 # make sure you have the "~/.okta_aws_login_config" locally first!
 touch ~/.okta_aws_login_config && \
-alias gimme-aws-creds="docker run -it --rm \
-  -v ~/.aws/credentials:/root/.aws/credentials \
+alias gimme-aws-creds-docker="docker run -it --rm \
+  -v ~/.aws/credentials2:/root/.aws/credentials \
   -v ~/.okta_aws_login_config:/root/.okta_aws_login_config \
   gimme-aws-creds"
 ```
@@ -208,6 +208,7 @@ A configuration wizard will prompt you to enter the necessary configuration para
   - token:hardware - OTP using hardware like Yubikey
   - call - OTP via Voice call
   - sms - OTP via SMS message
+  - email - OTP via email
   - web - DUO uses localhost webbrowser to support push|call|passcode
   - passcode - DUO uses `OKTA_MFA_CODE` or `--mfa-code` if set, or prompts user for passcode(OTP).
   

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ To make it easier you can also create an alias for the gimme-aws-creds command w
 ```bash
 # make sure you have the "~/.okta_aws_login_config" locally first!
 touch ~/.okta_aws_login_config && \
-alias gimme-aws-creds-docker="docker run -it --rm \
-  -v ~/.aws/credentials2:/root/.aws/credentials \
+alias gimme-aws-creds="docker run -it --rm \
+  -v ~/.aws/credentials:/root/.aws/credentials \
   -v ~/.okta_aws_login_config:/root/.okta_aws_login_config \
   gimme-aws-creds"
 ```

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -515,6 +515,7 @@ class Config(object):
             - token:hardware - OTP using hardware like Yubikey
             - call - OTP via Voice call
             - sms - OTP via SMS message
+            - email - OTP via email message
             - web - DUO uses localhost webbrowser to support push|call|passcode
             - passcode - DUO uses `OKTA_MFA_CODE` or `--mfa-code` if set, or prompts user for passcode(OTP).
             """


### PR DESCRIPTION
This PR adds an option to use email as a factor for MFA

## Description

Currently, email isn't supported as a factor for MFA. This PR adds email as a factor. Its pretty much the same as sms coding wise and I just had to make a few changes. I added tests as well.

## Related Issue

https://github.com/Nike-Inc/gimme-aws-creds/issues/394

## Motivation and Context

I use email for MFA.

## How Has This Been Tested?


I tested locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
