### PR TITLE
Notify user of U2F/WebAuthn token touch/insertion

### DIFF
--- a/gimme_aws_creds/okta_classic.py
+++ b/gimme_aws_creds/okta_classic.py
@@ -655,6 +655,7 @@ class OktaClassicClient(object):
         verify = FactorU2F(self.ui, app_id, nonce, credential_id)
         try:
             client_data, signature = verify.verify()
+            self.ui.notify("Received U2F token response.")
         except Exception:
             signature = b'fake'
             client_data = b'fake'
@@ -690,6 +691,7 @@ class OktaClassicClient(object):
         # noinspection PyBroadException
         try:
             client_data, assertion = webauthn_client.verify()
+            self.ui.notify("Received WebAuthn token response")
         except Exception:
             client_data = b'fake'
             assertion = FakeAssertion()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
No response is sent to the user when they insert or touch their WebAuthn/U2F token.  To the user, it's hard to tell if the token is being used or not.

## Related Issue
#410 

## Motivation and Context
#348 provided a notification that authentication was successful, but there's still a long lag after the user touches the token waiting on the response from Okta.  This change notifies the user as soon as they activate the token

## How Has This Been Tested?
Tested with multiple Yubikey and Google Titan devices

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
