### PR TITLE
Accept "y" or "Y" when saving to keyring

### DIFF
--- a/gimme_aws_creds/okta_classic.py
+++ b/gimme_aws_creds/okta_classic.py
@@ -920,7 +920,7 @@ class OktaClassicClient(object):
 
             if self.KEYRING_ENABLED:
                 # If the OS supports a keyring, offer to save the password
-                if self.ui.input("Do you want to save this password in the keyring? (y/N) ") == 'y':
+                if self.ui.input("Do you want to save this password in the keyring? (y/N) ").lower() == 'y':
                     try:
                         keyring.set_password(self.KEYRING_SERVICE, username, password)
                         self.ui.info("Password for {} saved in keyring.".format(username))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
entering 'Y' or 'y' `Do you want to save this password in the keyring? (y/N)` is accepted as a "yes"

## Related Issue
#330 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
