### PR TITLE
Replace getpass with ui.input(hidden=True)

### DIFF
--- a/gimme_aws_creds/okta_classic.py
+++ b/gimme_aws_creds/okta_classic.py
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and* limitations
 """
 import base64
 import copy
-import getpass
 import re
 import socket
 import time
@@ -914,7 +913,7 @@ class OktaClassicClient(object):
             # via OKTA_USERNAME env and user might not remember.
             for x in range(0, 5):
                 passwd_prompt = "Okta Password for {}: ".format(username)
-                password = getpass.getpass(prompt=passwd_prompt)
+                password = self.ui.input(message=passwd_prompt, hidden=True)
                 if len(password) > 0:
                     break
 

--- a/gimme_aws_creds/webauthn.py
+++ b/gimme_aws_creds/webauthn.py
@@ -12,7 +12,6 @@ See the License for the specific language governing permissions and* limitations
 
 from __future__ import print_function, absolute_import, unicode_literals
 
-from getpass import getpass
 from threading import Event, Thread
 
 from ctap_keyring_device.ctap_keyring_device import CtapKeyringDevice
@@ -140,13 +139,12 @@ class WebAuthnClient(object):
             self.ui.info('Operation timed out or no valid Security Key found !')
             raise FIDODeviceTimeoutError
 
-    @staticmethod
-    def _get_pin_from_client(client):
+    def _get_pin_from_client(self, client):
         if not client.info.options.get(CtapOptions.CLIENT_PIN):
             return None
 
         # Prompt for PIN if needed
-        pin = getpass("Please enter PIN: ")
+        pin = self.ui.input(message="Please enter PIN: ", hidden=True)
         return pin
 
     @staticmethod


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I'm currently trying to automate gimme-aws-creds in a python script.
I admire the idea of the `gimme_aws_creds.ui.UserInterface` class that helps a lot in automating user input.
I found that some places in the code was directly calling `getpass.getpass()` and not using the provided `UserInterface`. Replacing those calls with the proper `UserInterface.input(hidden=True)`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #428

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allowing developers subclassing `gimme_aws_creds.ui.UserInterface` for automation to provide inputs for password themselves.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ran `pytest -vv tests` with no errors
- Tested it with a script mocking the user input via a subclass of `UserInterface`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
