### PR TITLE
Add Duo Universal Prompt support to Okta Classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,11 @@ A configuration wizard will prompt you to enter the necessary configuration para
   - email - OTP via email
   - web - DUO uses localhost webbrowser to support push|call|passcode
   - passcode - DUO uses `OKTA_MFA_CODE` or `--mfa-code` if set, or prompts user for passcode(OTP).
-  
+  - claims_provider - DUO Universal Prompt
+- duo_universal_factor - (optional) Configure which type of factor to use with Duo Universal Prompt. Must be one of (case-sensitive):
+  - `Duo Push` (default)
+  - `Passcode`
+  - `Phone Call`
 - resolve_aws_alias - y or n. If yes, gimme-aws-creds will try to resolve AWS account ids with respective alias names (default: n). This option can also be set interactively in the command line using `-r` or `--resolve` parameter
 - include_path - (optional) Includes full role path to the role name in AWS credential profile name. (default: n).  If `y`: `<acct>-/some/path/administrator`. If `n`: `<acct>-administrator`
 - remember_device - y or n. If yes, the MFA device will be remembered by Okta service for a limited time. This option can also be set interactively in the command line using `-m` or `--remember-device`

--- a/gimme_aws_creds/duo_universal.py
+++ b/gimme_aws_creds/duo_universal.py
@@ -1,0 +1,197 @@
+import time
+
+import html5lib
+from furl import furl
+
+from . import version
+
+
+class DuoMfaDenied(BaseException):
+    """ Duo MFA was denied """
+
+    def __init__(self, response):
+        super(DuoMfaDenied, self).__init__(f'Duo MFA denied: {response}')
+
+
+class OktaDuoUniversal:
+    """ Handles interaction with the Duo Universal Prompt """
+
+    def __init__(self, ui, session, state_token, okta_factor, remember_device, duo_factor='Duo Push', duo_passcode=None):
+        self.ui = ui
+        self.state_token = state_token
+        self.okta_factor = okta_factor
+        self.remember_device = remember_device
+        self.session = session
+        if duo_factor not in ['Duo Push', 'Passcode', 'Phone Call']:
+            raise Exception('Preferred Duo Universal factor must be one of: Duo Push, Passcode, Phone Call')
+        self.duo_factor = duo_factor
+        self.duo_passcode = duo_passcode
+
+    def do_auth(self):
+        """ Follow Duo Universal Prompt flow through to an active Okta user session """
+
+        duo_prompt_url, okta_profile_login = self._initiate_okta_factor_verification()
+        duo_origin, duo_plugin_form_response = self._handle_duo_plugin_form(duo_prompt_url)
+
+        # Submit second Duo form (login-form), which triggers a Duo Push, phone call, or accepts the Passcode
+        login_form_action, duo_login_form_data = self._get_duo_universal_login_form_data(duo_plugin_form_response)
+        login_form_action_url = furl(duo_origin) / login_form_action
+        duo_factor, duo_sid, duo_txid, duo_xsrf = self._submit_duo_login_form(duo_login_form_data,
+                                                                              login_form_action_url)
+
+        self.ui.info(f"Duo Universal: Using {self.duo_factor}...")
+
+        self._wait_for_duo_universal_transaction(duo_origin, duo_txid, duo_sid)
+
+        # Once Duo has been approved, load the OIDC exit URL to be redirected to Okta and gain a user session
+        oidc_exit_url = furl(duo_origin) / 'frame/v4/oidc/exit'
+        exit_headers = self._get_form_headers()
+        exit_response = self.session.post(
+            oidc_exit_url.url,
+            data={
+                'txid': duo_txid,
+                'sid': duo_sid,
+                'factor': duo_factor,
+                '_xsrf': duo_xsrf,
+                'device_key': '',
+                'dampen_choice': 'false',
+            },
+            headers=exit_headers,
+        )
+        exit_response.raise_for_status()
+
+        # The claims_provider factor immediately yields an active user session, no subsequent request for SID required.
+        return {
+            'apiResponse': {
+                'status': 'SUCCESS',
+                'userSession': {
+                    "username": okta_profile_login,
+                    "session": self.session.cookies['sid'],
+                    "device_token": self.session.cookies['DT']
+                }
+            },
+        }
+
+    def _submit_duo_login_form(self, duo_login_form_data, login_form_action_url):
+        # Submit Duo's form id=login-form, which triggers a Duo Push, phone call, or accepts a Passcode.
+        duo_login_form_response = self.session.post(
+            login_form_action_url.url,
+            data=duo_login_form_data,
+            headers=self._get_form_headers(),
+        )
+        duo_login_form_response.raise_for_status()
+        duo_sid = duo_login_form_data['sid']
+        duo_factor = duo_login_form_data['factor']
+        duo_xsrf = duo_login_form_data['_xsrf']
+        duo_login_response_data = duo_login_form_response.json()
+        if duo_login_response_data['stat'] != 'OK':
+            raise Exception(f"Triggering Duo MFA failed: {duo_login_form_response.content}")
+        duo_txid = duo_login_response_data['response']['txid']
+        return duo_factor, duo_sid, duo_txid, duo_xsrf
+
+    def _handle_duo_plugin_form(self, duo_prompt_url):
+        # Request Duo prompt
+        verify_get_response = self.session.get(
+            duo_prompt_url,
+        )
+        verify_get_response.raise_for_status()
+        duo_origin = furl(verify_get_response.url).origin
+        # Submit first Duo form (plugin_form)
+        form_data = self._get_duo_universal_plugin_form_data(verify_get_response)
+        duo_plugin_form_response = self.session.post(
+            verify_get_response.url,
+            data=form_data,
+            headers=self._get_form_headers(),
+        )
+        duo_plugin_form_response.raise_for_status()
+        return duo_origin, duo_plugin_form_response
+
+    def _initiate_okta_factor_verification(self):
+        # POST to the Okta factor verify URL gives us the URL to request to load Duo
+        verify_post_response = self.session.post(
+            self.okta_factor['_links']['verify']['href'],
+            params={'rememberDevice': self.remember_device},
+            json={'stateToken': self.state_token},
+        )
+        verify_post_response.raise_for_status()
+        verify_response_data = verify_post_response.json()
+        duo_prompt_url = verify_response_data['_links']['next']['href']
+        okta_profile_login = verify_response_data['_embedded']['user']['profile']['login']
+        return duo_prompt_url, okta_profile_login
+
+    def _wait_for_duo_universal_transaction(self, duo_host, txid, sid):
+        status_url = furl(duo_host) / 'frame/v4/status'
+        status_data = {
+            'txid': txid,
+            'sid': sid
+        }
+        headers = self._get_form_headers()
+
+        tries = 0
+        while tries < 16:
+            tries += 1
+            time.sleep(0.5)
+
+            status_response = self.session.post(
+                status_url.url,
+                data=status_data,
+                headers=headers,
+            )
+            status_response.raise_for_status()
+
+            json_response = status_response.json()
+            if json_response['stat'] != 'OK':
+                raise Exception(f"Error checking Duo MFA status: {status_response.text}")
+
+            if json_response['response']['status_code'] == 'allow':
+                return txid
+            if json_response['response']['status_code'] == 'deny':
+                raise DuoMfaDenied(json_response)
+
+        raise Exception('Timed out waiting for Duo MFA')
+
+    @staticmethod
+    def _get_form_headers():
+        form_headers = {
+            'User-Agent': "gimme-aws-creds {}".format(version),
+            'Accept': 'application/json',
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+        }
+        return form_headers
+
+    def _get_duo_universal_login_form_data(self, plugin_form_response):
+        """ Get form data to post when submitting the Duo login-form """
+
+        doc = html5lib.parse(plugin_form_response.content, namespaceHTMLElements=False)
+        form_action = doc.find('.//form[@id="login-form"]').get('action')
+        form_data = {}
+        for field in doc.iterfind('.//form[@id="login-form"]/input'):
+            form_data[field.get('name')] = field.get('value')
+
+        preferred_device = self._find_device_to_use(doc)
+
+        form_data['factor'] = self.duo_factor
+        form_data['device'] = preferred_device
+        form_data['postAuthDestination'] = 'OIDC_EXIT'
+        if self.duo_passcode:
+            form_data['passcode'] = self.duo_passcode
+
+        return form_action, form_data
+
+    @staticmethod
+    def _find_device_to_use(doc):
+        device = doc.find('.//input[@name="preferred_device"]').get('value')
+        if device is None or device == '':
+            device = doc.find('.//select[@name="device"]/option').get('value')
+        return device
+
+    @staticmethod
+    def _get_duo_universal_plugin_form_data(response):
+        """ Get form data to post when submitting the Duo plugin_form """
+
+        doc = html5lib.parse(response.content, namespaceHTMLElements=False)
+        form_data = {}
+        for field in doc.iterfind('.//form[@id="plugin_form"]/input'):
+            form_data[field.get('name')] = field.get('value')
+
+        return form_data

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -579,6 +579,9 @@ class GimmeAWSCreds(object):
             if self.conf_dict.get('preferred_mfa_type'):
                 okta.set_preferred_mfa_type(self.conf_dict['preferred_mfa_type'])
 
+            if self.conf_dict.get('duo_universal_factor'):
+                okta.set_duo_universal_factor(self.conf_dict.get('duo_universal_factor'))
+
             if self.config.mfa_code is not None:
                 okta.set_mfa_code(self.config.mfa_code)
             elif self.conf_dict.get('okta_mfa_code'):

--- a/gimme_aws_creds/okta_classic.py
+++ b/gimme_aws_creds/okta_classic.py
@@ -32,6 +32,7 @@ from requests.adapters import HTTPAdapter, Retry
 from gimme_aws_creds.u2f import FactorU2F
 from gimme_aws_creds.webauthn import WebAuthnClient, FakeAssertion
 from . import errors, ui, version, duo
+from .duo_universal import OktaDuoUniversal
 from .errors import GimmeAWSCredsMFAEnrollStatus
 from .registered_authenticators import RegisteredAuthenticators
 
@@ -62,6 +63,7 @@ class OktaClassicClient(object):
         self._username = None
         self._password = None
         self._preferred_mfa_type = None
+        self._duo_universal_factor = 'Duo Push'
         self._mfa_code = None
         self._remember_device = None
 
@@ -103,6 +105,9 @@ class OktaClassicClient(object):
 
     def set_mfa_code(self, mfa_code):
         self._mfa_code = mfa_code
+
+    def set_duo_universal_factor(self, duo_universal_factor):
+        self._duo_universal_factor = duo_universal_factor
 
     def set_remember_device(self, remember_device):
         self._remember_device = bool(remember_device)
@@ -158,30 +163,33 @@ class OktaClassicClient(object):
         """ Authenticate the user and return the Okta Session ID and username"""
         login_response = self.auth()
 
-        session_url = self._okta_org_url + '/login/sessionCookieRedirect'
-
-        if 'redirect_uri' not in kwargs:
-            redirect_uri = 'http://localhost:8080/login'
+        if 'userSession' in login_response:
+            return login_response['userSession']
         else:
-            redirect_uri = kwargs['redirect_uri']
+            session_url = self._okta_org_url + '/login/sessionCookieRedirect'
 
-        params = {
-            'token': login_response['sessionToken'],
-            'redirectUrl': redirect_uri
-        }
+            if 'redirect_uri' not in kwargs:
+                redirect_uri = 'http://localhost:8080/login'
+            else:
+                redirect_uri = kwargs['redirect_uri']
 
-        response = self._http_client.get(
-            session_url,
-            params=params,
-            headers=self._get_headers(),
-            verify=self._verify_ssl_certs,
-            allow_redirects=False
-        )
-        return {
-            "username": login_response['_embedded']['user']['profile']['login'],
-            "session": response.cookies['sid'],
-            "device_token": self._http_client.cookies['DT']
-        }
+            params = {
+                'token': login_response['sessionToken'],
+                'redirectUrl': redirect_uri
+            }
+
+            response = self._http_client.get(
+                session_url,
+                params=params,
+                headers=self._get_headers(),
+                verify=self._verify_ssl_certs,
+                allow_redirects=False
+            )
+            return {
+                "username": login_response['_embedded']['user']['profile']['login'],
+                "session": response.cookies['sid'],
+                "device_token": self._http_client.cookies['DT']
+            }
 
     def auth_oauth(self, client_id, **kwargs):
         """ Login to Okta and retrieve access token, ID token or both """
@@ -451,6 +459,19 @@ class OktaClassicClient(object):
         if 'sessionToken' in response_data:
             return {'stateToken': None, 'sessionToken': response_data['sessionToken'], 'apiResponse': response_data}
 
+    def _login_duo_universal(self, state_token, factor):
+        duo_passcode = None
+        if self._duo_universal_factor == 'Passcode':
+            duo_passcode = self.ui.input(message='Duo Passcode: ')
+        duo_client = OktaDuoUniversal(self.ui,
+                                      self._http_client,
+                                      state_token,
+                                      factor,
+                                      self._remember_device,
+                                      self._duo_universal_factor,
+                                      duo_passcode)
+        return duo_client.do_auth()
+
     def _login_input_webauthn_challenge(self, state_token, factor):
         """ Retrieve nonce """
         response = self._http_client.post(
@@ -593,6 +614,8 @@ class OktaClassicClient(object):
             return self._login_input_webauthn_challenge(state_token, factor)
         elif factor['factorType'] == 'token:hardware':
             return self._login_input_mfa_challenge(state_token, factor['_links']['verify']['href'])
+        elif factor['factorType'] == 'claims_provider':
+            return self._login_duo_universal(state_token, factor)
 
     def _login_input_mfa_challenge(self, state_token, next_url):
         """ Submit verification code for SMS or TOTP authentication methods"""
@@ -717,7 +740,7 @@ class OktaClassicClient(object):
         else:
             return {'stateToken': None, 'sessionToken': None, 'apiResponse': response_data}
 
-    def get_saml_response(self, url, auth_session = None):
+    def get_saml_response(self, url, auth_session=None):
         """ return the base64 SAML value object from the SAML Response"""
         response = self._http_client.get(url, verify=self._verify_ssl_certs)
         response.raise_for_status()
@@ -888,6 +911,8 @@ class OktaClassicClient(object):
             return factor['factorType'] + ": " + factor_name
         elif factor['factorType'] == 'token:hardware':
             return factor['factorType'] + ": " + factor['provider']
+        elif factor['factorType'] == 'claims_provider':
+            return factor['factorType'] + ": " + factor['vendorName']
 
         else:
             return "Unknown MFA type: " + factor['factorType']
@@ -1063,7 +1088,7 @@ class OktaClassicClient(object):
     @staticmethod
     def _extract_state_token_from_http_response(http_res):
         # extract the stateToken from a javascript variable
-        state_token_re =  re.search(r"var stateToken = '(.*)';", http_res.text)
+        state_token_re = re.search(r"var stateToken = '(.*)';", http_res.text)
         if state_token_re is not None:
             return decode(state_token_re.group(1), "unicode-escape")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ okta>=0.0.4,<1.0.0
 ctap-keyring-device==1.0.6
 pyjwt>=2.4.0,<3.0.0
 urllib3>=1.26.0,<2.0.0
+html5lib>=1.1,<2.0.0
+furl>=2.1.3,<3.0.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+import os
+
+
+def read_fixture(file_name):
+    """Read a fixture file"""
+    fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures', file_name)
+    with open(fixture_path, 'r', encoding='utf-8') as file:
+        return file.read()

--- a/tests/fixtures/duo_universal_login_form.html
+++ b/tests/fixtures/duo_universal_login_form.html
@@ -1,0 +1,391 @@
+<!DOCTYPE html>
+<!--[if IE 8]> <html lang="en" class="ie ie8"> <![endif]-->
+<!--[if IE 9]> <html lang="en" class="ie ie9"> <![endif]-->
+<!--[if gt IE 9]><!--> <html lang="en"> <!--<![endif]-->
+<head>
+<meta charset="utf-8">
+
+<!-- Set latest compatibility for IE -->
+<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+<meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0">
+
+<title>
+Two-Factor Authentication
+</title>
+<!-- Import for all versions of IE, in case the standards mode is downgraded to IE8 -->
+<!--[if IE]> <link rel="stylesheet" href="&#x2f;frame&#x2f;static&#x2f;css&#x2f;v3&#x2f;ie8.css&#x3f;v&#x3d;e9b26"> <![endif]-->
+
+<link rel="stylesheet" href="&#x2f;frame&#x2f;static&#x2f;css&#x2f;normalize.css&#x3f;v&#x3d;a674e">
+<link rel="stylesheet" href="&#x2f;frame&#x2f;static&#x2f;fonts&#x2f;ss-standard&#x2f;ss-standard.css&#x3f;v&#x3d;a8885">
+<link rel="stylesheet" href="&#x2f;frame&#x2f;static&#x2f;css&#x2f;fonts&#x2f;duo-admin.css&#x3f;v&#x3d;50a8a">
+<link rel="stylesheet" href="&#x2f;frame&#x2f;static&#x2f;css&#x2f;v3&#x2f;base.css&#x3f;v&#x3d;39c22">
+
+<link rel="stylesheet" href="&#x2f;frame&#x2f;static&#x2f;css&#x2f;tipsy.css&#x3f;v&#x3d;4217a">
+
+
+</head>
+<body>
+<div class="oidc-wrapper">
+<div class="base-wrapper ">
+
+<div class="base-main">
+<div role="main" class="base-body">
+
+<form action="/frame/prompt" method="post" id="login-form" class="inline login-form hidden">
+<input type="hidden" name="sid" value="frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa">
+<input type="hidden" name="url" value="/frame/prompt">
+<input type="hidden" name="enrollment_message" value="">
+<input type="hidden" name="itype" value="okta">
+
+<input type="hidden" name="_xsrf" value="xsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxs" />
+
+<input type="hidden" name="ukey" value="duoukeyvalue">
+
+<input type="hidden" name="out_of_date" value="False">
+<input type="hidden" name="days_out_of_date" value="0">
+<input type="hidden" name="should_update_dm" value="False">
+
+
+<input type="hidden" name="preferred_factor" value="Duo&#x20;Push">
+<input type="hidden" name="preferred_device" value="phone1">
+
+<input type="hidden" name="days_to_block" value="None">
+<input type="hidden" name="should_retry_u2f_timeouts" value="True">
+
+<input type="hidden" id="has_phone_that_requires_compliance_text" name="has_phone_that_requires_compliance_text" value="False">
+
+<fieldset class="device-selector ">
+<h1 class="cramped-frame-view">
+Device&#x3a;
+</h1>
+<div class="device-select-wrapper">
+<select name="device" aria-label="Device" tabindex=2>
+
+
+
+
+
+<option value="phone1">Phone 1 &#x28;XXX-XXX-1111&#x29;</option>
+
+
+<option value="phone2">Phone 2 &#x28;XXX-XXX-2222&#x29;</option>
+
+
+<option value="phone3">Phone 3 &#x28;XXX-XXX-3333&#x29;</option>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</select>
+
+</div>
+</fieldset>
+
+<div id="auth_methods">
+
+<fieldset data-device-index="phone1" class="hidden">
+<h2 class="medium-or-larger auth-method-header">
+Choose an authentication method
+</h2>
+
+
+<div class="row-label push-label">
+<input type="hidden" name="factor" value="Duo&#x20;Push">
+<span class="label factor-label">
+<i class="icon-smartphone-check"></i>
+Duo Push
+
+
+<small class="used-automatically">
+<i class="icon-check"></i>
+Used automatically
+</small>
+
+
+</span>
+<button tabindex="2" type="submit" class="positive&#x20;auth-button" ><!-- -->Send Me a Push </button>
+</div>
+
+
+
+
+<div class="row-label phone-label">
+<input type="hidden" name="factor" value="Phone&#x20;Call">
+<span class="label factor-label">
+<i class="icon-call-ringing" alt="" role="presentation"></i>
+Call Me
+
+</span>
+<button tabindex="2" type="submit" class="positive&#x20;auth-button" ><!-- -->Call Me </button>
+</div>
+
+<div class="passcode-label row-label">
+<input type="hidden" name="factor" value="Passcode">
+<span class="label factor-label">
+<i class="icon-smartphone-ellipsis" alt="" role="presentation"></i>
+Passcode
+</span>
+<div class="passcode-input-wrapper">
+<input type="text" name="passcode" autocomplete="off" data-index="phone1" class="hidden passcode-input" placeholder="ex.&#x20;867539" aria-label="passcode" tabindex=2>
+<div class="next-passcode-msg" role="alert" aria-live="polite"></div>
+</div>
+<button tabindex="2" type="submit" id="passcode" class="positive&#x20;auth-button" ><!-- -->Enter a Passcode </button>
+<input name="phone-smsable" type="hidden" value="True" />
+<input name="mobile-otpable" type="hidden" value="True" />
+<input name="next-passcode" type="hidden" value="None" />
+</div>
+
+</fieldset>
+
+<fieldset data-device-index="phone2" class="hidden">
+<h2 class="medium-or-larger auth-method-header">
+Choose an authentication method
+</h2>
+
+
+<div class="row-label push-label">
+<input type="hidden" name="factor" value="Duo&#x20;Push">
+<span class="label factor-label">
+<i class="icon-smartphone-check"></i>
+Duo Push
+
+
+
+</span>
+<button tabindex="2" type="submit" class="positive&#x20;auth-button" ><!-- -->Send Me a Push </button>
+</div>
+
+
+
+
+<div class="row-label phone-label">
+<input type="hidden" name="factor" value="Phone&#x20;Call">
+<span class="label factor-label">
+<i class="icon-call-ringing" alt="" role="presentation"></i>
+Call Me
+
+</span>
+<button tabindex="2" type="submit" class="positive&#x20;auth-button" ><!-- -->Call Me </button>
+</div>
+
+<div class="passcode-label row-label">
+<input type="hidden" name="factor" value="Passcode">
+<span class="label factor-label">
+<i class="icon-smartphone-ellipsis" alt="" role="presentation"></i>
+Passcode
+</span>
+<div class="passcode-input-wrapper">
+<input type="text" name="passcode" autocomplete="off" data-index="phone2" class="hidden passcode-input" placeholder="ex.&#x20;867539" aria-label="passcode" tabindex=2>
+<div class="next-passcode-msg" role="alert" aria-live="polite"></div>
+</div>
+<button tabindex="2" type="submit" id="passcode" class="positive&#x20;auth-button" ><!-- -->Enter a Passcode </button>
+<input name="phone-smsable" type="hidden" value="True" />
+<input name="mobile-otpable" type="hidden" value="True" />
+<input name="next-passcode" type="hidden" value="None" />
+</div>
+
+</fieldset>
+
+<fieldset data-device-index="phone3" class="hidden">
+<h2 class="medium-or-larger auth-method-header">
+Choose an authentication method
+</h2>
+
+
+<div class="row-label push-label">
+<input type="hidden" name="factor" value="Duo&#x20;Push">
+<span class="label factor-label">
+<i class="icon-smartphone-check"></i>
+Duo Push
+
+
+
+</span>
+<button tabindex="2" type="submit" class="positive&#x20;auth-button" ><!-- -->Send Me a Push </button>
+</div>
+
+
+
+
+<div class="row-label phone-label">
+<input type="hidden" name="factor" value="Phone&#x20;Call">
+<span class="label factor-label">
+<i class="icon-call-ringing" alt="" role="presentation"></i>
+Call Me
+
+</span>
+<button tabindex="2" type="submit" class="positive&#x20;auth-button" ><!-- -->Call Me </button>
+</div>
+
+<div class="passcode-label row-label">
+<input type="hidden" name="factor" value="Passcode">
+<span class="label factor-label">
+<i class="icon-smartphone-ellipsis" alt="" role="presentation"></i>
+Passcode
+</span>
+<div class="passcode-input-wrapper">
+<input type="text" name="passcode" autocomplete="off" data-index="phone3" class="hidden passcode-input" placeholder="ex.&#x20;867539" aria-label="passcode" tabindex=2>
+<div class="next-passcode-msg" role="alert" aria-live="polite"></div>
+</div>
+<button tabindex="2" type="submit" id="passcode" class="positive&#x20;auth-button" ><!-- -->Enter a Passcode </button>
+<input name="phone-smsable" type="hidden" value="True" />
+<input name="mobile-otpable" type="hidden" value="True" />
+<input name="next-passcode" type="hidden" value="None" />
+</div>
+
+</fieldset>
+
+
+
+
+
+<input type="hidden" name="has-token" value="false">
+
+
+</div>
+
+<div>
+
+</div>
+</form>
+
+
+
+<form class="oidc-exit-form" action="/frame/prompt/oidc/exit" method="POST">
+<input type="hidden" name="txid" value="" />
+<input type="hidden" name="sid" value="frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa" />
+<input type="hidden" name="_xsrf" value="xsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxs" />
+</form>
+
+
+</div>
+</div>
+<div class="base-navigation">
+
+<div class="base-navigation">
+<div role="banner">
+
+<a href="&#x2f;frame&#x2f;prompt&#x3f;sid&#x3d;frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa">
+<img src="&#x2f;frame&#x2f;logo&#x3f;sid&#x3d;frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa" alt="Example&#x20;Authentication" width="128"/>
+</a>
+
+</div>
+<div class="help-sidebar">
+<button class='btn btn-support'>
+<i class="icon-align-justify" aria-label="Open"></i>
+<i class="icon-delete" aria-label="Close"></i>
+Settings
+</button>
+<div class="help-links">
+<nav role="navigation">
+
+<a id="help_link" class="help-nav" href="https&#x3a;&#x2f;&#x2f;guide.duo.com&#x2f;prompt" target="_blank" aria-label="What&#x20;is&#x20;the&#x20;Duo&#x20;Prompt&#x3f;&#x20;&#x28;Opens&#x20;in&#x20;a&#x20;new&#x20;tab.&#x29;">
+What is this&#x3f;<i class="icon-new-window"></i>
+</a>
+
+
+<a class="help-nav" id="new-device" href="/frame/enroll/pre_flow_prompt?sid=frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa&post_auth_action=addDevice">
+Add a new device
+</a>
+<a class="help-nav" href="/frame/enroll/pre_flow_prompt?sid=frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa&post_auth_action=manageDevices">
+My Settings &amp; Devices
+</a>
+
+<a href="#" class="need-help">Need help&#x3f;</a>
+</nav>
+
+<div role="contentinfo">
+<a href="https&#x3a;&#x2f;&#x2f;duo.com" class="branding-link" target="_blank" rel="noreferrer noopener">
+Secured by Duo
+</a>
+</div>
+
+
+</div>
+
+</div>
+<div class="help-overlay offscreen">
+<div class="help-links">
+<nav role="navigation">
+
+<a id="help_link" class="help-nav" href="https&#x3a;&#x2f;&#x2f;guide.duo.com&#x2f;prompt" target="_blank" aria-label="What&#x20;is&#x20;the&#x20;Duo&#x20;Prompt&#x3f;&#x20;&#x28;Opens&#x20;in&#x20;a&#x20;new&#x20;tab.&#x29;">
+What is this&#x3f;<i class="icon-new-window"></i>
+</a>
+
+
+<a class="help-nav" id="new-device" href="/frame/enroll/pre_flow_prompt?sid=frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa&post_auth_action=addDevice">
+Add a new device
+</a>
+<a class="help-nav" href="/frame/enroll/pre_flow_prompt?sid=frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa&post_auth_action=manageDevices">
+My Settings &amp; Devices
+</a>
+
+<a href="#" class="need-help">Need help&#x3f;</a>
+</nav>
+
+<div role="contentinfo">
+<a href="https&#x3a;&#x2f;&#x2f;duo.com" class="branding-link" target="_blank" rel="noreferrer noopener">
+Secured by Duo
+</a>
+</div>
+
+
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="base-sidebar">
+
+</div>
+<div id="messages-view" class="hidden">
+<div class="messages-list">
+
+</div>
+</div>
+
+
+</div>
+</div>
+<script id="translations" type="text/json">
+{"locale_data": {"js-messages": {"": {"domain": "js-messages", "lang": "en", "plural_forms": "nplurals&#x3d;2&#x3b; plural&#x3d;&#x28;n &#x21;&#x3d; 1&#x29;&#x3b;"}}}, "domain": "js-messages"}
+</script>
+
+
+<!-- Hidden XSRF input needed for POST requests made by errors.js -->
+<input type="hidden" name="_xsrf" value="xsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxs" />
+
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;jquery&#x2f;jquery-prologue.js&#x3f;v&#x3d;400dc"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;jquery&#x2f;jquery.min.js&#x3f;v&#x3d;ff152"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;he&#x2f;he.min.js&#x3f;v&#x3d;aaa33"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;js&#x2f;lib&#x2f;jquery-postmessage.min.js&#x3f;v&#x3d;98c73"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;lodash&#x2f;lodash.min.js&#x3f;v&#x3d;6585f"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;backbone&#x2f;backbone-min.js&#x3f;v&#x3d;e0ff6"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;js&#x2f;page&#x2f;v3&#x2f;frame.js&#x3f;v&#x3d;4baee"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;js&#x2f;page&#x2f;v3&#x2f;base.js&#x3f;v&#x3d;deba4"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;validator&#x2f;validator.min.js&#x3f;v&#x3d;9a068"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;jquery&#x2f;jquery-epilogue.js&#x3f;v&#x3d;c4ac5"></script>
+<script id="browser_exceptions" src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;js&#x2f;errors.js&#x3f;v&#x3d;d10d2" data-url="/frame/browser_exceptions"></script>
+<input type="hidden" name="helpdesk-message" id="helpdesk-message" value="&quot;Contact&#x20;the&#x20;global&#x20;help&#x20;desk,&#x20;Americas&#x3a;&#x20;&#x2b;1.312.635.6520,&#x20;&#x20;EMEA&#x3a;&#x20;&#x2b;3.140.298.1500,&#x20;APAC&#x3a;&#x20;&#x2b;9.122.6607.9800&quot;" />
+<!--[if lt IE 10]>
+<script src="&#x2f;frame&#x2f;static&#x2f;js&#x2f;page&#x2f;v3&#x2f;quirks.js&#x3f;v&#x3d;d6bd9"></script>
+<![endif]-->
+
+
+<script src="&#x2f;frame&#x2f;static&#x2f;js&#x2f;lib&#x2f;jquery.tipsy.js&#x3f;v&#x3d;c0432"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;js&#x2f;page&#x2f;v3&#x2f;prompt.js&#x3f;v&#x3d;1a59b"></script>
+
+
+</body>
+</html>

--- a/tests/fixtures/duo_universal_login_form_without_preferred_device.html
+++ b/tests/fixtures/duo_universal_login_form_without_preferred_device.html
@@ -1,0 +1,405 @@
+<!DOCTYPE html>
+<!--[if IE 8]>
+<html lang="en" class="ie ie8"> <![endif]-->
+<!--[if IE 9]>
+<html lang="en" class="ie ie9"> <![endif]-->
+<!--[if gt IE 9]><!-->
+<html lang="en"> <!--<![endif]-->
+<head>
+    <meta charset="utf-8">
+
+    <!-- Set latest compatibility for IE -->
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0">
+
+    <title>
+        Two-Factor Authentication
+    </title>
+    <!-- Import for all versions of IE, in case the standards mode is downgraded to IE8 -->
+    <!--[if IE]> <link rel="stylesheet" href="&#x2f;frame&#x2f;static&#x2f;css&#x2f;v3&#x2f;ie8.css&#x3f;v&#x3d;e9b26"> <![endif]-->
+
+    <link rel="stylesheet" href="&#x2f;frame&#x2f;static&#x2f;css&#x2f;normalize.css&#x3f;v&#x3d;a674e">
+    <link rel="stylesheet"
+          href="&#x2f;frame&#x2f;static&#x2f;fonts&#x2f;ss-standard&#x2f;ss-standard.css&#x3f;v&#x3d;a8885">
+    <link rel="stylesheet" href="&#x2f;frame&#x2f;static&#x2f;css&#x2f;fonts&#x2f;duo-admin.css&#x3f;v&#x3d;50a8a">
+    <link rel="stylesheet" href="&#x2f;frame&#x2f;static&#x2f;css&#x2f;v3&#x2f;base.css&#x3f;v&#x3d;39c22">
+
+    <link rel="stylesheet" href="&#x2f;frame&#x2f;static&#x2f;css&#x2f;tipsy.css&#x3f;v&#x3d;4217a">
+
+
+</head>
+<body>
+<div class="oidc-wrapper">
+    <div class="base-wrapper ">
+
+        <div class="base-main">
+            <div role="main" class="base-body">
+
+                <form action="/frame/prompt" method="post" id="login-form" class="inline login-form hidden">
+                    <input type="hidden" name="sid" value="frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa">
+                    <input type="hidden" name="url" value="/frame/prompt">
+                    <input type="hidden" name="enrollment_message" value="">
+                    <input type="hidden" name="itype" value="okta">
+
+                    <input type="hidden" name="_xsrf" value="xsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxs"/>
+
+                    <input type="hidden" name="ukey" value="duoukeyvalue">
+
+                    <input type="hidden" name="out_of_date" value="False">
+                    <input type="hidden" name="days_out_of_date" value="0">
+                    <input type="hidden" name="should_update_dm" value="False">
+
+
+                    <input type="hidden" name="preferred_factor" value="">
+                    <input type="hidden" name="preferred_device" value="">
+
+                    <input type="hidden" name="days_to_block" value="None">
+                    <input type="hidden" name="should_retry_u2f_timeouts" value="True">
+
+                    <input type="hidden" id="has_phone_that_requires_compliance_text"
+                           name="has_phone_that_requires_compliance_text" value="False">
+
+                    <fieldset class="device-selector ">
+                        <h1 class="cramped-frame-view">
+                            Device&#x3a;
+                        </h1>
+                        <div class="device-select-wrapper">
+                            <select name="device" aria-label="Device" tabindex=2>
+
+
+                                <option value="phone1">Phone 1 &#x28;XXX-XXX-1111&#x29;</option>
+
+
+                                <option value="phone2">Phone 2 &#x28;XXX-XXX-2222&#x29;</option>
+
+
+                                <option value="phone3">Phone 3 &#x28;XXX-XXX-3333&#x29;</option>
+
+
+                            </select>
+
+                        </div>
+                    </fieldset>
+
+                    <div id="auth_methods">
+
+                        <fieldset data-device-index="phone1" class="hidden">
+                            <h2 class="medium-or-larger auth-method-header">
+                                Choose an authentication method
+                            </h2>
+
+
+                            <div class="row-label push-label">
+                                <input type="hidden" name="factor" value="Duo&#x20;Push">
+                                <span class="label factor-label">
+        <i class="icon-smartphone-check"></i>
+        Duo Push
+
+
+        <small class="used-automatically">
+        <i class="icon-check"></i>
+        Used automatically
+        </small>
+
+
+        </span>
+                                <button tabindex="2" type="submit" class="positive&#x20;auth-button"><!-- -->Send Me a
+                                    Push
+                                </button>
+                            </div>
+
+
+                            <div class="row-label phone-label">
+                                <input type="hidden" name="factor" value="Phone&#x20;Call">
+                                <span class="label factor-label">
+        <i class="icon-call-ringing" alt="" role="presentation"></i>
+        Call Me
+
+        </span>
+                                <button tabindex="2" type="submit" class="positive&#x20;auth-button"><!-- -->Call Me
+                                </button>
+                            </div>
+
+                            <div class="passcode-label row-label">
+                                <input type="hidden" name="factor" value="Passcode">
+                                <span class="label factor-label">
+        <i class="icon-smartphone-ellipsis" alt="" role="presentation"></i>
+        Passcode
+        </span>
+                                <div class="passcode-input-wrapper">
+                                    <input type="text" name="passcode" autocomplete="off" data-index="phone1"
+                                           class="hidden passcode-input" placeholder="ex.&#x20;867539"
+                                           aria-label="passcode" tabindex=2>
+                                    <div class="next-passcode-msg" role="alert" aria-live="polite"></div>
+                                </div>
+                                <button tabindex="2" type="submit" id="passcode" class="positive&#x20;auth-button">
+                                    <!-- -->Enter a Passcode
+                                </button>
+                                <input name="phone-smsable" type="hidden" value="True"/>
+                                <input name="mobile-otpable" type="hidden" value="True"/>
+                                <input name="next-passcode" type="hidden" value="None"/>
+                            </div>
+
+                        </fieldset>
+
+                        <fieldset data-device-index="phone2" class="hidden">
+                            <h2 class="medium-or-larger auth-method-header">
+                                Choose an authentication method
+                            </h2>
+
+
+                            <div class="row-label push-label">
+                                <input type="hidden" name="factor" value="Duo&#x20;Push">
+                                <span class="label factor-label">
+        <i class="icon-smartphone-check"></i>
+        Duo Push
+
+
+
+        </span>
+                                <button tabindex="2" type="submit" class="positive&#x20;auth-button"><!-- -->Send Me a
+                                    Push
+                                </button>
+                            </div>
+
+
+                            <div class="row-label phone-label">
+                                <input type="hidden" name="factor" value="Phone&#x20;Call">
+                                <span class="label factor-label">
+        <i class="icon-call-ringing" alt="" role="presentation"></i>
+        Call Me
+
+        </span>
+                                <button tabindex="2" type="submit" class="positive&#x20;auth-button"><!-- -->Call Me
+                                </button>
+                            </div>
+
+                            <div class="passcode-label row-label">
+                                <input type="hidden" name="factor" value="Passcode">
+                                <span class="label factor-label">
+        <i class="icon-smartphone-ellipsis" alt="" role="presentation"></i>
+        Passcode
+        </span>
+                                <div class="passcode-input-wrapper">
+                                    <input type="text" name="passcode" autocomplete="off" data-index="phone2"
+                                           class="hidden passcode-input" placeholder="ex.&#x20;867539"
+                                           aria-label="passcode" tabindex=2>
+                                    <div class="next-passcode-msg" role="alert" aria-live="polite"></div>
+                                </div>
+                                <button tabindex="2" type="submit" id="passcode" class="positive&#x20;auth-button">
+                                    <!-- -->Enter a Passcode
+                                </button>
+                                <input name="phone-smsable" type="hidden" value="True"/>
+                                <input name="mobile-otpable" type="hidden" value="True"/>
+                                <input name="next-passcode" type="hidden" value="None"/>
+                            </div>
+
+                        </fieldset>
+
+                        <fieldset data-device-index="phone3" class="hidden">
+                            <h2 class="medium-or-larger auth-method-header">
+                                Choose an authentication method
+                            </h2>
+
+
+                            <div class="row-label push-label">
+                                <input type="hidden" name="factor" value="Duo&#x20;Push">
+                                <span class="label factor-label">
+        <i class="icon-smartphone-check"></i>
+        Duo Push
+
+
+
+        </span>
+                                <button tabindex="2" type="submit" class="positive&#x20;auth-button"><!-- -->Send Me a
+                                    Push
+                                </button>
+                            </div>
+
+
+                            <div class="row-label phone-label">
+                                <input type="hidden" name="factor" value="Phone&#x20;Call">
+                                <span class="label factor-label">
+        <i class="icon-call-ringing" alt="" role="presentation"></i>
+        Call Me
+
+        </span>
+                                <button tabindex="2" type="submit" class="positive&#x20;auth-button"><!-- -->Call Me
+                                </button>
+                            </div>
+
+                            <div class="passcode-label row-label">
+                                <input type="hidden" name="factor" value="Passcode">
+                                <span class="label factor-label">
+        <i class="icon-smartphone-ellipsis" alt="" role="presentation"></i>
+        Passcode
+        </span>
+                                <div class="passcode-input-wrapper">
+                                    <input type="text" name="passcode" autocomplete="off" data-index="phone3"
+                                           class="hidden passcode-input" placeholder="ex.&#x20;867539"
+                                           aria-label="passcode" tabindex=2>
+                                    <div class="next-passcode-msg" role="alert" aria-live="polite"></div>
+                                </div>
+                                <button tabindex="2" type="submit" id="passcode" class="positive&#x20;auth-button">
+                                    <!-- -->Enter a Passcode
+                                </button>
+                                <input name="phone-smsable" type="hidden" value="True"/>
+                                <input name="mobile-otpable" type="hidden" value="True"/>
+                                <input name="next-passcode" type="hidden" value="None"/>
+                            </div>
+
+                        </fieldset>
+
+
+                        <input type="hidden" name="has-token" value="false">
+
+
+                    </div>
+
+                    <div>
+
+                    </div>
+                </form>
+
+
+                <form class="oidc-exit-form" action="/frame/prompt/oidc/exit" method="POST">
+                    <input type="hidden" name="txid" value=""/>
+                    <input type="hidden" name="sid" value="frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa"/>
+                    <input type="hidden" name="_xsrf" value="xsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxs"/>
+                </form>
+
+
+            </div>
+        </div>
+        <div class="base-navigation">
+
+            <div class="base-navigation">
+                <div role="banner">
+
+                    <a href="&#x2f;frame&#x2f;prompt&#x3f;sid&#x3d;frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa">
+                        <img src="&#x2f;frame&#x2f;logo&#x3f;sid&#x3d;frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa"
+                             alt="Example&#x20;Authentication" width="128"/>
+                    </a>
+
+                </div>
+                <div class="help-sidebar">
+                    <button class='btn btn-support'>
+                        <i class="icon-align-justify" aria-label="Open"></i>
+                        <i class="icon-delete" aria-label="Close"></i>
+                        Settings
+                    </button>
+                    <div class="help-links">
+                        <nav role="navigation">
+
+                            <a id="help_link" class="help-nav" href="https&#x3a;&#x2f;&#x2f;guide.duo.com&#x2f;prompt"
+                               target="_blank"
+                               aria-label="What&#x20;is&#x20;the&#x20;Duo&#x20;Prompt&#x3f;&#x20;&#x28;Opens&#x20;in&#x20;a&#x20;new&#x20;tab.&#x29;">
+                                What is this&#x3f;<i class="icon-new-window"></i>
+                            </a>
+
+
+                            <a class="help-nav" id="new-device"
+                               href="/frame/enroll/pre_flow_prompt?sid=frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa&post_auth_action=addDevice">
+                                Add a new device
+                            </a>
+                            <a class="help-nav"
+                               href="/frame/enroll/pre_flow_prompt?sid=frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa&post_auth_action=manageDevices">
+                                My Settings &amp; Devices
+                            </a>
+
+                            <a href="#" class="need-help">Need help&#x3f;</a>
+                        </nav>
+
+                        <div role="contentinfo">
+                            <a href="https&#x3a;&#x2f;&#x2f;duo.com" class="branding-link" target="_blank"
+                               rel="noreferrer noopener">
+                                Secured by Duo
+                            </a>
+                        </div>
+
+
+                    </div>
+
+                </div>
+                <div class="help-overlay offscreen">
+                    <div class="help-links">
+                        <nav role="navigation">
+
+                            <a id="help_link" class="help-nav" href="https&#x3a;&#x2f;&#x2f;guide.duo.com&#x2f;prompt"
+                               target="_blank"
+                               aria-label="What&#x20;is&#x20;the&#x20;Duo&#x20;Prompt&#x3f;&#x20;&#x28;Opens&#x20;in&#x20;a&#x20;new&#x20;tab.&#x29;">
+                                What is this&#x3f;<i class="icon-new-window"></i>
+                            </a>
+
+
+                            <a class="help-nav" id="new-device"
+                               href="/frame/enroll/pre_flow_prompt?sid=frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa&post_auth_action=addDevice">
+                                Add a new device
+                            </a>
+                            <a class="help-nav"
+                               href="/frame/enroll/pre_flow_prompt?sid=frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa&post_auth_action=manageDevices">
+                                My Settings &amp; Devices
+                            </a>
+
+                            <a href="#" class="need-help">Need help&#x3f;</a>
+                        </nav>
+
+                        <div role="contentinfo">
+                            <a href="https&#x3a;&#x2f;&#x2f;duo.com" class="branding-link" target="_blank"
+                               rel="noreferrer noopener">
+                                Secured by Duo
+                            </a>
+                        </div>
+
+
+                    </div>
+
+                </div>
+            </div>
+
+        </div>
+        <div class="base-sidebar">
+
+        </div>
+        <div id="messages-view" class="hidden">
+            <div class="messages-list">
+
+            </div>
+        </div>
+
+
+    </div>
+</div>
+<script id="translations" type="text/json">
+    {"locale_data": {"js-messages": {"": {"domain": "js-messages", "lang": "en", "plural_forms": "nplurals&#x3d;2&#x3b; plural&#x3d;&#x28;n &#x21;&#x3d; 1&#x29;&#x3b;"}}}, "domain": "js-messages"}
+</script>
+
+
+<!-- Hidden XSRF input needed for POST requests made by errors.js -->
+<input type="hidden" name="_xsrf" value="xsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxs"/>
+
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;jquery&#x2f;jquery-prologue.js&#x3f;v&#x3d;400dc"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;jquery&#x2f;jquery.min.js&#x3f;v&#x3d;ff152"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;he&#x2f;he.min.js&#x3f;v&#x3d;aaa33"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;js&#x2f;lib&#x2f;jquery-postmessage.min.js&#x3f;v&#x3d;98c73"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;lodash&#x2f;lodash.min.js&#x3f;v&#x3d;6585f"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;backbone&#x2f;backbone-min.js&#x3f;v&#x3d;e0ff6"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;js&#x2f;page&#x2f;v3&#x2f;frame.js&#x3f;v&#x3d;4baee"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;js&#x2f;page&#x2f;v3&#x2f;base.js&#x3f;v&#x3d;deba4"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;validator&#x2f;validator.min.js&#x3f;v&#x3d;9a068"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;jquery&#x2f;jquery-epilogue.js&#x3f;v&#x3d;c4ac5"></script>
+<script id="browser_exceptions" src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;js&#x2f;errors.js&#x3f;v&#x3d;d10d2"
+        data-url="/frame/browser_exceptions"></script>
+<input type="hidden" name="helpdesk-message" id="helpdesk-message"
+       value="&quot;Contact&#x20;the&#x20;global&#x20;help&#x20;desk,&#x20;Americas&#x3a;&#x20;&#x2b;1.312.635.6520,&#x20;&#x20;EMEA&#x3a;&#x20;&#x2b;3.140.298.1500,&#x20;APAC&#x3a;&#x20;&#x2b;9.122.6607.9800&quot;"/>
+<!--[if lt IE 10]>
+<script src="&#x2f;frame&#x2f;static&#x2f;js&#x2f;page&#x2f;v3&#x2f;quirks.js&#x3f;v&#x3d;d6bd9"></script>
+<![endif]-->
+
+
+<script src="&#x2f;frame&#x2f;static&#x2f;js&#x2f;lib&#x2f;jquery.tipsy.js&#x3f;v&#x3d;c0432"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;js&#x2f;page&#x2f;v3&#x2f;prompt.js&#x3f;v&#x3d;1a59b"></script>
+
+
+</body>
+</html>

--- a/tests/fixtures/duo_universal_plugin_form.html
+++ b/tests/fixtures/duo_universal_plugin_form.html
@@ -1,0 +1,62 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<title>Duo Security - Two-Factor Authentication</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Content-Language" content="en-us">
+<!-- CSS -->
+<link rel="stylesheet" href="&#x2f;frame&#x2f;static&#x2f;css&#x2f;v3&#x2f;base.css&#x3f;v&#x3d;39c22">
+
+<link rel="stylesheet" href="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;plugin-detect&#x2f;plugin-detect.min.css&#x3f;v&#x3d;01376">
+
+</head>
+<body>
+<div id="wrapper">
+
+<form method="post" id="plugin_form">
+
+<input type="hidden" name="tx" value="tttttttttttttttttttttttttttttttttttt.tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt.ttttt_tt-tttttttttttttttttttttttt_tttttttttttttttttttttttttt_ttttttttttttttttttt-tt-tt" />
+
+
+
+<input type="hidden" name="parent" value="None" />
+
+
+<input type="hidden" name="_xsrf" value="xsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxs" />
+
+
+
+
+<input type="hidden" name="java_version" value="" />
+<input type="hidden" name="flash_version" value="" />
+<input type="hidden" name="screen_resolution_width" value="" />
+<input type="hidden" name="screen_resolution_height" value="" />
+<input type="hidden" name="color_depth" value="" />
+<input type="hidden" name="ch_ua_error" value="" />
+<input type="hidden" name="client_hints" value="" />
+
+<input type="hidden" name="is_cef_browser" value=""/>
+<input type="hidden" name="is_ipad_os" value="" />
+<input type="hidden" name="is_ie_compatibility_mode" value="" />
+<input type="hidden" name="is_user_verifying_platform_authenticator_available" value="" />
+<input type="hidden" name="user_verifying_platform_authenticator_available_error" value="" />
+<input type="hidden" name="acting_ie_version" value="" />
+<div id='react-test-container'></div>
+<input type="hidden" name="react_support" value="" />
+<input type="hidden" name="react_support_error_message" value="" />
+
+</form>
+
+</div>
+<!-- Javascript -->
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;jquery&#x2f;jquery-prologue.js&#x3f;v&#x3d;400dc"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;jquery&#x2f;jquery.min.js&#x3f;v&#x3d;ff152"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;js&#x2f;lib&#x2f;jquery-postmessage.min.js&#x3f;v&#x3d;98c73"></script>
+
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;plugin-detect&#x2f;plugin-detect.min.js&#x3f;v&#x3d;6a394"></script>
+<script src="&#x2f;frame&#x2f;static&#x2f;js&#x2f;page&#x2f;preauth.js&#x3f;v&#x3d;154e6"></script>
+
+<script src="&#x2f;frame&#x2f;static&#x2f;shared&#x2f;lib&#x2f;jquery&#x2f;jquery-epilogue.js&#x3f;v&#x3d;c4ac5"></script>
+</body>
+</html>

--- a/tests/test_aws_resolver.py
+++ b/tests/test_aws_resolver.py
@@ -1,6 +1,5 @@
 """Unit tests for gimme_aws_creds"""
 import sys
-import os
 import unittest
 from contextlib import contextmanager
 from io import StringIO
@@ -10,13 +9,9 @@ import responses
 
 import gimme_aws_creds.common as common_def
 from gimme_aws_creds.aws import AwsResolver
+from tests import read_fixture
 
-def read_fixture(file_name):
-    """Read a fixture file"""
-    fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures', file_name)
-    with open(fixture_path, 'r', encoding='utf-8') as file:
-        return file.read()
-    
+
 class TestAwsResolver(unittest.TestCase):
     """Class to test Okta Client Class.
        Mock is used to mock external calls"""
@@ -109,4 +104,3 @@ class TestAwsResolver(unittest.TestCase):
         self.assertEqual(result[4], self.display_role[4])
         self.assertEqual(result[5], self.display_role[5])
         self.assertEqual(result[6], self.display_role[6])
-		

--- a/tests/test_duo_universal_client.py
+++ b/tests/test_duo_universal_client.py
@@ -1,0 +1,325 @@
+import json
+import unittest
+from unittest.mock import Mock
+
+import requests
+import responses
+from tests import read_fixture
+
+from gimme_aws_creds.duo_universal import OktaDuoUniversal
+from tests.user_interface_mock import MockUserInterface
+
+
+class TestDuoUniversalClient(unittest.TestCase):
+    def setUp(self):
+        self.OKTA_STATE_TOKEN = 'statetokenstatetokenstatetokenstatetokenstateto'
+        self.OKTA_LOGIN = 'okta.user@example.com'
+        self.OKTA_FIRST_NAME = 'Okta'
+        self.OKTA_LAST_NAME = 'User'
+        self.OKTA_FACTOR_ID = 'oktafactorid'
+        self.OKTA_FACTOR = {
+            'factorType': 'claims_provider',
+            'provider': 'CUSTOM',
+            'vendorName': 'Duo Universal Prompt',
+            '_links': {
+                'verify': {
+                    'href': 'https://oktatenant.oktapreview.com/sso/idps/foo/verify',
+                    'hints': {
+                        'allow': ['POST']
+                    }
+                }
+            }
+        }
+        self.OKTA_DT_VALUE = 'oktadtvalue'
+        self.OKTA_SID_VALUE = 'oktasidvalue'
+
+        self.REQ_0_OKTA_AUTHN_FACTORS_VERIFY_RESPONSE = {
+            'stateToken': self.OKTA_STATE_TOKEN,
+            'expiresAt': '2100-10-17T19:35:07.000Z', 'status': 'MFA_CHALLENGE',
+            'factorResult': 'CHALLENGE',
+            '_embedded': {
+                'user': {
+                    'id': 'oktauseridoktauserid',
+                    'passwordChanged': '2100-05-17T18:56:58.000Z',
+                    'profile': {
+                        'login': self.OKTA_LOGIN,
+                        'firstName': self.OKTA_FIRST_NAME,
+                        'lastName': self.OKTA_LAST_NAME,
+                        'locale': 'en_US', 'timeZone': 'America/Los_Angeles'
+                    }
+                },
+                'factor': {
+                    'id': self.OKTA_FACTOR_ID,
+                    'factorType': 'claims_provider',
+                    'provider': 'CUSTOM',
+                    'vendorName': 'Duo Universal Prompt'},
+                'policy': {
+                    'allowRememberDevice': True,
+                    'rememberDeviceLifetimeInMinutes': 720,
+                    'rememberDeviceByDefault': False,
+                    'factorsPolicyInfo': {}
+                }
+            },
+            '_links': {
+                'next': {
+                    'name': 'redirect',
+                    'href': f'https://oktatenant.oktapreview.com/sso/idps/oktaclaimsidpid?stateToken={self.OKTA_STATE_TOKEN}',
+                    'hints': {
+                        'allow': ['GET']
+                    }
+                },
+                'cancel': {
+                    'href': 'https://oktatenant.oktapreview.com/api/v1/authn/cancel',
+                    'hints': {
+                        'allow': ['POST']
+                    }
+                },
+                'prev': {
+                    'href': 'https://oktatenant.oktapreview.com/api/v1/authn/previous',
+                    'hints': {
+                        'allow': ['POST']
+                    }
+                }
+            }
+        }
+        self.DUO_ORIGIN = 'https://duo-tenant.duosecurity.com'
+        self.DUO_TX = 'tttttttttttttttttttttttttttttttttttt.tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt.ttttt_tt-tttttttttttttttttttttttt_tttttttttttttttttttttttttt_ttttttttttttttttttt-tt-tt'
+        self.DUO_SID = 'frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa'
+        self.DUO_AUTHORIZE_URL = f'{self.DUO_ORIGIN}/oauth/v1/authorize?client_id=oktaclientidoktaclientid&response_type=code&scope=openid&request=rrrrrrrrrrrrrrrrrrrr.rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr._rrrrrrrrrrr-rrrrrrrrrrrrrrrrrrrrrrrrrrrrrr'
+        self.DUO_FRAMELESS_AUTH_PATH = f'/frame/frameless/v4/auth?sid={self.DUO_SID}&tx={self.DUO_TX}'
+        self.DUO_PROMPT_PATH = '/frame/prompt?sid=frameless-aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaaa'
+        self.DUO_XSRF = 'xsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxs'
+        self.DUO_PLUGIN_FORM_CONTENT = read_fixture('duo_universal_plugin_form.html')
+        self.DUO_LOGIN_FORM_CONTENT = read_fixture('duo_universal_login_form.html')
+        self.DUO_TXID = 'txidtxid-txid-txid-txid-txidtxid'
+        self.DUO_LOGIN_FORM_SUBMISSION_RESPONSE = {
+            'stat': 'OK',
+            'response': {
+                'txid': self.DUO_TXID
+            }
+        }
+        self.DUO_STATUS_PUSH_IN_PROGRESS_RESPONSE = {
+            'stat': 'OK',
+            'response': {
+                'status_enum': 13,
+                'status_code': 'pushed'
+            }
+        }
+        self.DUO_STATUS_PUSH_COMPLETE_RESPONSE = {
+            'stat': 'OK',
+            'response': {
+                'status_enum': 5,
+                'status_code': 'allow',
+                'result': 'SUCCESS',
+                'reason': 'User approved',
+                'post_auth_action': 'oidc_exit'
+            }
+        }
+
+    @responses.activate(registry=responses.registries.OrderedRegistry)
+    def test_universal_push(self):
+        self.configure_duo_responses(duo_factor='Duo Push')
+
+        session = requests.Session()
+        duo = OktaDuoUniversal(ui=MockUserInterface(),
+                               session=session,
+                               state_token=self.OKTA_STATE_TOKEN,
+                               okta_factor=self.OKTA_FACTOR,
+                               remember_device=True,
+                               duo_factor='Duo Push')
+        result = duo.do_auth()
+        assert result == {
+            'apiResponse': {
+                'status': 'SUCCESS',
+                'userSession': {
+                    'username': self.OKTA_LOGIN,
+                    'session': self.OKTA_SID_VALUE,
+                    'device_token': self.OKTA_DT_VALUE
+                }
+            },
+        }
+
+    @responses.activate(registry=responses.registries.OrderedRegistry)
+    def test_universal_phone_call(self):
+        self.configure_duo_responses(duo_factor='Phone Call')
+        session = requests.Session()
+        duo = OktaDuoUniversal(ui=MockUserInterface(),
+                               session=session,
+                               state_token=self.OKTA_STATE_TOKEN,
+                               okta_factor=self.OKTA_FACTOR,
+                               remember_device=True,
+                               duo_factor='Phone Call')
+        result = duo.do_auth()
+        assert result == {
+            'apiResponse': {
+                'status': 'SUCCESS',
+                'userSession': {
+                    'username': self.OKTA_LOGIN,
+                    'session': self.OKTA_SID_VALUE,
+                    'device_token': self.OKTA_DT_VALUE
+                }
+            },
+        }
+
+    @responses.activate(registry=responses.registries.OrderedRegistry)
+    def test_universal_passcode(self):
+        self.configure_duo_responses(duo_factor='Passcode', passcode='12345')
+        session = requests.Session()
+        duo = OktaDuoUniversal(ui=MockUserInterface(),
+                               session=session,
+                               state_token=self.OKTA_STATE_TOKEN,
+                               okta_factor=self.OKTA_FACTOR,
+                               remember_device=True,
+                               duo_factor='Passcode',
+                               duo_passcode='12345')
+        result = duo.do_auth()
+        assert result == {
+            'apiResponse': {
+                'status': 'SUCCESS',
+                'userSession': {
+                    'username': self.OKTA_LOGIN,
+                    'session': self.OKTA_SID_VALUE,
+                    'device_token': self.OKTA_DT_VALUE
+                }
+            },
+        }
+
+    def test_no_preferred_device(self):
+        session = requests.Session()
+        login_form_response = Mock()
+        login_form_response.content = read_fixture('duo_universal_login_form_without_preferred_device.html')
+        duo = OktaDuoUniversal(ui=MockUserInterface(),
+                               session=session,
+                               state_token=self.OKTA_STATE_TOKEN,
+                               okta_factor=self.OKTA_FACTOR,
+                               remember_device=True,
+                               duo_factor='Passcode',
+                               duo_passcode='12345')
+        form_action, form_data = duo._get_duo_universal_login_form_data(login_form_response)
+        assert form_data['device'] == 'phone1'
+
+    def configure_duo_responses(self, duo_factor, passcode=None):
+        # Initial request to Okta to verify IDP factor
+        responses.add(responses.POST,
+                      self.OKTA_FACTOR['_links']['verify']['href'] + '?rememberDevice=True',
+                      body=json.dumps(self.REQ_0_OKTA_AUTHN_FACTORS_VERIFY_RESPONSE),
+                      match=[
+                          responses.matchers.json_params_matcher(
+                              {
+                                  'stateToken': self.OKTA_STATE_TOKEN
+                              }
+                          )]
+                      )
+        # Request to Okta IDP next step
+        responses.add(method=responses.GET,
+                      url=self.REQ_0_OKTA_AUTHN_FACTORS_VERIFY_RESPONSE['_links']['next']['href'],
+                      status=302,
+                      adding_headers={
+                          'Location': self.DUO_AUTHORIZE_URL,
+                          'Set-Cookie': f'DT={self.OKTA_DT_VALUE};Version=1;Path=/;Max-Age=63072000;Secure;Expires=Thu, 16 Oct 2100 19:30:07 GMT;HttpOnly'
+                      })
+        # Duo redirects a couple of times before presenting a form
+        responses.add(method=responses.GET,
+                      url=self.DUO_AUTHORIZE_URL,
+                      status=303,
+                      adding_headers={
+                          'Location': self.DUO_FRAMELESS_AUTH_PATH
+                      })
+        responses.add(method=responses.GET,
+                      url=self.DUO_ORIGIN + self.DUO_FRAMELESS_AUTH_PATH,
+                      body=self.DUO_PLUGIN_FORM_CONTENT
+                      )
+        # Duo plugin-form submission
+        responses.add(method=responses.POST,
+                      url=self.DUO_ORIGIN + self.DUO_FRAMELESS_AUTH_PATH,
+                      status=302,
+                      adding_headers={
+                          'Location': self.DUO_PROMPT_PATH
+                      },
+                      match=[
+                          responses.matchers.urlencoded_params_matcher(
+                              {
+                                  'tx': self.DUO_TX,
+                                  '_xsrf': self.DUO_XSRF,
+                                  'parent': 'None',
+                              }
+                          )]
+                      )
+        # Duo presents a second form, login-form
+        responses.add(method=responses.GET,
+                      url=self.DUO_ORIGIN + self.DUO_PROMPT_PATH,
+                      body=self.DUO_LOGIN_FORM_CONTENT
+                      )
+        # login-form submit, which triggers Push or Phone call if that's what the user wanted
+        duo_login_form_values = {
+            # Important to Duo
+            'sid': self.DUO_SID,
+            'postAuthDestination': 'OIDC_EXIT',
+            'factor': duo_factor,
+            'device': 'phone1',
+            '_xsrf': 'xsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxsrfxs',
+            # Unimportant for triggering universal MFA, but part of the form inputs
+            'should_update_dm': 'False',
+            'should_retry_u2f_timeouts': 'True',
+            'preferred_factor': 'Duo Push',
+            'preferred_device': 'phone1',
+            'out_of_date': 'False',
+            'itype': 'okta',
+            'has_phone_that_requires_compliance_text': 'False',
+            'days_to_block': 'None',
+            'days_out_of_date': '0',
+            'url': '/frame/prompt',
+            'ukey': 'duoukeyvalue'
+        }
+        if passcode:
+            duo_login_form_values['passcode'] = passcode
+        responses.add(method=responses.POST,
+                      url=self.DUO_ORIGIN + '/frame/prompt',
+                      body=json.dumps(self.DUO_LOGIN_FORM_SUBMISSION_RESPONSE),
+                      match=[responses.matchers.urlencoded_params_matcher(
+                          duo_login_form_values)]
+                      )
+        # 'No response yet' status
+        responses.add(method=responses.POST,
+                      url=self.DUO_ORIGIN + '/frame/v4/status',
+                      body=json.dumps(self.DUO_STATUS_PUSH_IN_PROGRESS_RESPONSE),
+                      match=[responses.matchers.urlencoded_params_matcher(
+                          {
+                              'txid': self.DUO_TXID,
+                              'sid': self.DUO_SID,
+                          })]
+                      )
+        # 'User approved' status
+        responses.add(method=responses.POST,
+                      url=self.DUO_ORIGIN + '/frame/v4/status',
+                      body=json.dumps(self.DUO_STATUS_PUSH_COMPLETE_RESPONSE),
+                      match=[responses.matchers.urlencoded_params_matcher(
+                          {
+                              'txid': self.DUO_TXID,
+                              'sid': self.DUO_SID,
+                          })]
+                      )
+        # Client posts to a Duo OIDC exit URL, which redirects to Okta
+        okta_oidc_callback = 'https://oktatenant.oktapreview.com/oauth2/v1/authorize/callback?state=oidcexitstate&code=oidccode'
+        responses.add(method=responses.POST,
+                      url=self.DUO_ORIGIN + '/frame/v4/oidc/exit',
+                      status=303,
+                      adding_headers={
+                          'Location': okta_oidc_callback
+                      },
+                      match=[responses.matchers.urlencoded_params_matcher(
+                          {
+                              'txid': self.DUO_TXID,
+                              'sid': self.DUO_SID,
+                              'dampen_choice': 'false',
+                              '_xsrf': self.DUO_XSRF,
+                              'factor': duo_factor,
+                          })]
+                      )
+        responses.add(method=responses.GET,
+                      url=okta_oidc_callback,
+                      body='<html></html>',
+                      adding_headers={
+                          'Set-Cookie': f'sid={self.OKTA_SID_VALUE};Version=1;Path=/;Secure'
+                      }
+                      )


### PR DESCRIPTION
## Description

Add Duo Universal Prompt + Okta Classic support, including Duo Push, Phone Call, and Passcode methods of approving.

## Related Issue
#431

## Motivation and Context
Duo is sunsetting their Traditional prompt in March 2024, so we need to migrate completely to Universal Prompt by then. Many of our people utilize gimme-aws-creds in their daily workflows, so I'm interested in contributing support for it.

[Duo Universal Prompt integration with Okta](https://duo.com/docs/okta#duo-custom-idp-factor-in-okta-classic) is through a custom IDP. Okta presents this factor as a `claims_provider` type, which I've added to the relevant factor logic. I've made Duo Push the default Duo method and added a configuration setting for specifying whether to use Duo Push, Phone Call, or Passcode methods of approving.

Besides the new Duo interactions, the new factor type also behaves differently when it comes to yielding an active Okta session. The Universal Prompt redirects to an Okta URL that accepts the result from Duo and, assuming success, immediately grants an active user session. So, I adjusted `OktaClassicClient#auth_session()` to handle that case, where it does not need to separately access `login/sessionCookieRedirect` to get the session cookie.

## How Has This Been Tested?
I contacted our Duo support to determine the best API to use for driving Universal Prompt without a browser, and their answer was that there is none. It looks like it's the same for the traditional Duo prompt implementation in gimme-aws-creds. So, the implementation is based on observing the HTTP requests made by a browser when authenticating to Okta with Duo Universal Prompt MFA. I've added unit tests that verify the interactions and data flow match what I reverse engineered from those observations.

Additionally, I've tested the updated gimme-aws-creds end-to-end locally against our Okta Classic tenant that is integrated with Duo Universal Prompt and the traditional Duo integration. My manual test regime includes executing approved and disapproved MFA for Duo Push, Phone Call, and Passcode.

I'm running gimme-aws-creds on a Mac with Ventura 13.6.

## Screenshots (if appropriate):

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project. (I believe so, but do let me know if there's something I need to do to confirm)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (Note that the CLA link is broken, see #432.)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
