### PR TITLE
feat: support account name as cred_profile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ A configuration wizard will prompt you to enter the necessary configuration para
 - write_aws_creds - True or False - If True, the AWS credentials will be written to `~/.aws/credentials` otherwise it will be written to stdout.
 - cred_profile - If writing to the AWS cred file, this sets the name of the AWS credential profile.
   - The reserved word `role` will use the name component of the role arn as the profile name. i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [okta-1234-role] in the aws credentials file
-  - The reserved word `acc-role` will use the name component of the role arn prepended with account number (or alias if `resolve_aws_alias` is set to y) to avoid collisions, i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [123456789012-okta-1234-role], or if `resolve_aws_alias` [<my alias>-okta-1234-role] in the aws credentials file
+  - The reserved word `acc` will use the account number (or alias if `resolve_aws_alias` is set to y) as the profile name. i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [arn:aws:iam::123456789012] or if `resolve_aws_alias` [okta-1234-role] in the aws credentials file.
+  - The reserved word `acc-role` will use the name component of the role arn prepended with account number (or alias if `resolve_aws_alias` is set to y) to avoid collisions, i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [123456789012-okta-1234-role], or if `resolve_aws_alias` [okta-1234-role] in the aws credentials file
   - If set to `default` then the temp creds will be stored in the default profile
   - Note: if there are multiple roles, and `default` is selected it will be overwritten multiple times and last role wins. The same happens when `role` is selected and you have many accounts with the same role names. Consider using `acc-role` if this happens.
 - aws_appname - This is optional. The Okta AWS App name, which has the role you want to assume.
@@ -225,7 +226,7 @@ A configuration wizard will prompt you to enter the necessary configuration para
   - email - OTP via email
   - web - DUO uses localhost webbrowser to support push|call|passcode
   - passcode - DUO uses `OKTA_MFA_CODE` or `--mfa-code` if set, or prompts user for passcode(OTP).
-  
+
 - resolve_aws_alias - y or n. If yes, gimme-aws-creds will try to resolve AWS account ids with respective alias names (default: n). This option can also be set interactively in the command line using `-r` or `--resolve` parameter
 - include_path - (optional) Includes full role path to the role name in AWS credential profile name. (default: n).  If `y`: `<acct>-/some/path/administrator`. If `n`: `<acct>-administrator`
 - remember_device - y or n. If yes, the MFA device will be remembered by Okta service for a limited time. This option can also be set interactively in the command line using `-m` or `--remember-device`
@@ -374,7 +375,7 @@ for data in creds.iter_selected_aws_credentials():
         if len(piece) == 12 and piece.isdigit():
             account_id = piece
             break
-  
+
     if account_id is None:
         raise ValueError("Didn't find aws_account_id (12 digits) in {}".format(arn))
 
@@ -390,7 +391,7 @@ gimme-aws-creds works both on FIDO1 enabled org and WebAuthN enabled org
 Note that FIDO1 will probably be deprecated in the near future as standards moves forward to WebAuthN
 
 WebAuthN support is available for usb security keys (gimme-aws-creds relies on the yubico fido2 lib).
- 
+
 To use your local machine as an authenticator, along with Touch ID or Windows Hello, if available,
 you must register a new authenticator via gimme-aws-creds, using:
 ```bash

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -310,7 +310,7 @@ class Config(object):
         config_dict['aws_default_duration'] = self._get_aws_default_duration(defaults['aws_default_duration'])
         if config_dict['gimme_creds_server'] != 'appurl':
             config_dict['aws_appname'] = self._get_aws_appname(defaults['aws_appname'])
-        
+
         config_dict["output_format"] = ''
         if not config_dict["write_aws_creds"]:
             config_dict['output_format'] = self._get_output_format(defaults['output_format'])
@@ -489,6 +489,7 @@ class Config(object):
         ui.default.message(
             "The AWS credential profile defines which profile is used to store the temp AWS creds.\n"
             "If set to 'role' then a new profile will be created matching the role name assumed by the user.\n"
+            "If set to 'acc' then a new profile will be created matching the account number.\n"
             "If set to 'acc-role' then a new profile will be created matching the role name assumed by the user, but prefixed with account number to avoid collisions.\n"
             "If set to 'default' then the temp creds will be stored in the default profile\n"
             "If set to any other value, the name of the profile will match that value."
@@ -497,7 +498,7 @@ class Config(object):
         cred_profile = self._get_user_input(
             "AWS Credential Profile", default_entry)
 
-        if cred_profile.lower() in ['default', 'role', 'acc-role']:
+        if cred_profile.lower() in ['default', 'role', 'acc', 'acc-role']:
             cred_profile = cred_profile.lower()
 
         return cred_profile
@@ -598,7 +599,7 @@ class Config(object):
                     "Force classic login flow", default_entry)
             except ValueError:
                 ui.default.warning("Force Classic login flow must be either y or n.")
-    
+
     def _get_open_browser(self, default_entry):
         """Option to automatically open the default browser for OIE authentication"""
         ui.default.message(

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -40,7 +40,7 @@ class GimmeAWSCreds(object):
     """
        This is a CLI tool that gets temporary AWS credentials
        from Okta based on the available AWS Okta Apps and roles
-       assigned to the user. 
+       assigned to the user.
     """
     resolver = DefaultResolver()
     envvar_list = [
@@ -496,18 +496,18 @@ class GimmeAWSCreds(object):
 
     def set_okta_platform(self, okta_platform):
         self._cache['okta_platform'] = okta_platform
-    
+
     @property
     def okta_platform(self):
         if 'okta_platform' in self._cache:
             return self._cache['okta_platform']
-        
+
         # Treat this domain as classic, even if it's OIE
         if self.config.force_classic == True or self.conf_dict.get('force_classic') == "True":
             self.ui.message('Okta Classic login flow enabled')
             self.set_okta_platform('classic')
             return 'classic'
-        
+
         response = requests.get(
             self.okta_org_url + '/.well-known/okta-organization',
             headers={
@@ -666,10 +666,10 @@ class GimmeAWSCreds(object):
                     id_token=False,
                     scopes=['openid']
                 )
-                
+
                 # auth_session isn't needed when using gimme_creds_lambda and Okta classic
                 self.set_auth_session(None)
-                
+
             elif self.okta_platform == 'identity_engine':
                 auth_result = self.auth_session
 
@@ -800,14 +800,12 @@ class GimmeAWSCreds(object):
             profile_name = 'default'
         elif cred_profile.lower() == 'role':
             profile_name = naming_data['role']
+        elif cred_profile.lower() == 'acc':
+            profile_name = self._get_account_name(naming_data['account'], role, resolve_alias)
         elif cred_profile.lower() == 'acc-role':
-            account = naming_data['account']
+            account = self._get_account_name(naming_data['account'], role, resolve_alias)
             role_name = naming_data['role']
             path = naming_data['path']
-            if resolve_alias == 'True':
-                account_alias = self._get_alias_from_friendly_name(role.friendly_account_name)
-                if account_alias:
-                    account = account_alias
             if include_path == 'True':
                 role_name = ''.join([path, role_name])
             profile_name = '-'.join([account,
@@ -815,6 +813,12 @@ class GimmeAWSCreds(object):
         else:
             profile_name = cred_profile
         return profile_name
+
+    def _get_account_name(self, account, role, resolve_alias):
+        if resolve_alias == "False":
+            return account
+        account_alias = self._get_alias_from_friendly_name(role.friendly_account_name)
+        return account_alias or account
 
     def iter_selected_aws_credentials(self):
         results = []
@@ -850,8 +854,8 @@ class GimmeAWSCreds(object):
             self.handle_setup_fido_authenticator()
         self.handle_action_store_json_creds()
         self.handle_action_list_roles()
-            
-  
+
+
         # for each data item, if we have an override on output, prioritize that
         # if we do not, prioritize writing credentials to file if that is in our
         # configuration. If we are not writing to a credentials file, use whatever

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -115,7 +115,7 @@ class TestMain(unittest.TestCase):
         partition, region = creds._get_partition_and_region_from_saml_acs('https://signin.aws.amazon.com/saml')
         self.assertEqual(partition, 'aws')
         self.assertEqual(region, 'us-east-1')
-    
+
     def test_get_region_partition_aws(self):
         creds = GimmeAWSCreds()
 
@@ -228,6 +228,7 @@ class TestMain(unittest.TestCase):
         include_path = 'True'
         self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
                          "123456789012-/some/long/extended/path/administrator")
+
     def test_get_profile_name_role(self):
         "Testing the role"
         creds = GimmeAWSCreds()
@@ -241,6 +242,34 @@ class TestMain(unittest.TestCase):
         include_path = 'True'
         self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
                          'administrator')
+
+    def test_get_profile_name_account_resolve_alias(self):
+        "Testing the account with alias resolution"
+        creds = GimmeAWSCreds()
+        naming_data = {'account': '123456789012', 'role': 'administrator', 'path': '/administrator/'}
+        role = RoleSet(idp='arn:aws:iam::123456789012:saml-provider/my-okta-provider',
+                       role='arn:aws:iam::123456789012:role/administrator/administrator',
+                       friendly_account_name='Account: my-org-master (123456789012)',
+                       friendly_role_name='administrator/administrator')
+        cred_profile = 'acc'
+        resolve_alias = 'True'
+        include_path = 'True'
+        self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
+                         'my-org-master')
+
+    def test_get_profile_name_account_do_not_resolve_alias(self):
+        "Testing the account without alias resolution"
+        creds = GimmeAWSCreds()
+        naming_data = {'account': '123456789012', 'role': 'administrator', 'path': '/administrator/'}
+        role = RoleSet(idp='arn:aws:iam::123456789012:saml-provider/my-okta-provider',
+                       role='arn:aws:iam::123456789012:role/administrator/administrator',
+                       friendly_account_name='Account: my-org-master (123456789012)',
+                       friendly_role_name='administrator/administrator')
+        cred_profile = 'acc'
+        resolve_alias = 'False'
+        include_path = 'True'
+        self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
+                         '123456789012')
 
     def test_get_profile_name_default(self):
         "Testing the default"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Hi, This PR supports account name or id (depends on alias resolve option) as a credential profile name.

## Related Issue
N/A.

## Motivation and Context

Simplifying workflow I have where config profiles is inconsistent with creds names authoried by `gimme-aws-creds`

## How Has This Been Tested?

Unit tests passing:

```bash
(venv) ❯ pytest -vv tests
======================================================================== test session starts =========================================================================
platform darwin -- Python 3.11.2, pytest-7.4.3, pluggy-1.3.0 -- ~/code/gimme-aws-creds/venv/bin/python3.11
cachedir: .pytest_cache
rootdir: ~/code/gimme-aws-creds
collected 78 items           

tests/test_aws_resolver.py::TestAwsResolver::test_display_role PASSED [  1%]
tests/test_aws_resolver.py::TestAwsResolver::test_enumerate_saml_roles PASSED                                   [  2%]
tests/test_aws_resolver.py::TestAwsResolver::test_enumerate_saml_roles_nextjs PASSED                            [  3%]
tests/test_config.py::TestConfig::test_fail_if_profile_not_found PASSED                                         [  5%]
tests/test_config.py::TestConfig::test_get_args_username PASSED                                                 [  6%]
tests/test_config.py::TestConfig::test_read_config PASSED                                                       [  7%]
tests/test_config.py::TestConfig::test_read_config_inherited PASSED                                             [  8%]
tests/test_config.py::TestConfig::test_read_nested_config_inherited PASSED                                      [ 10%]
tests/test_main.py::TestMain::test_choose_roles_app_0 PASSED                                                    [ 11%]
tests/test_main.py::TestMain::test_choose_roles_app_1 PASSED                                                    [ 12%]
tests/test_main.py::TestMain::test_choose_roles_app_2 PASSED                                                    [ 14%]
tests/test_main.py::TestMain::test_choose_roles_app_a PASSED                                                    [ 15%]
tests/test_main.py::TestMain::test_choose_roles_app_neg1 PASSED                                                 [ 16%]
tests/test_main.py::TestMain::test_get_alias_from_friendly_name_no_alias PASSED                                 [ 17%]
tests/test_main.py::TestMain::test_get_alias_from_friendly_name_with_alias PASSED                               [ 19%]
tests/test_main.py::TestMain::test_get_partition_aws PASSED                                                     [ 20%]
tests/test_main.py::TestMain::test_get_partition_china PASSED                                                   [ 21%]
tests/test_main.py::TestMain::test_get_partition_govcloud PASSED                                                [ 23%]
tests/test_main.py::TestMain::test_get_partition_unkown PASSED                                                  [ 24%]
tests/test_main.py::TestMain::test_get_profile_accrole_name_do_not_resolve_alias_do_not_include_paths PASSED    [ 25%]
tests/test_main.py::TestMain::test_get_profile_accrole_name_do_not_resolve_alias_include_paths PASSED           [ 26%]
tests/test_main.py::TestMain::test_get_profile_name_account_do_not_resolve_alias PASSED                         [ 28%]
tests/test_main.py::TestMain::test_get_profile_name_account_resolve_alias PASSED                                [ 29%]
tests/test_main.py::TestMain::test_get_profile_name_accrole_resolve_alias_do_not_include_paths PASSED           [ 30%]
tests/test_main.py::TestMain::test_get_profile_name_default PASSED                                              [ 32%]
tests/test_main.py::TestMain::test_get_profile_name_else PASSED                                                 [ 33%]
tests/test_main.py::TestMain::test_get_profile_name_role PASSED                                                 [ 34%]
tests/test_main.py::TestMain::test_get_region_partition_aws PASSED                                              [ 35%]
tests/test_main.py::TestMain::test_get_region_partition_china PASSED                                            [ 37%]
tests/test_main.py::TestMain::test_get_region_partition_govcloud PASSED                                         [ 38%]
tests/test_main.py::TestMain::test_get_selected_app_from_config_0 PASSED                                        [ 39%]
tests/test_main.py::TestMain::test_get_selected_app_from_config_1 PASSED                                        [ 41%]
tests/test_main.py::TestMain::test_get_selected_roles_all PASSED                                                [ 42%]
tests/test_main.py::TestMain::test_get_selected_roles_from_config_0 PASSED                                      [ 43%]
tests/test_main.py::TestMain::test_get_selected_roles_from_config_1 PASSED                                      [ 44%]
tests/test_main.py::TestMain::test_get_selected_roles_multiple PASSED                                           [ 46%]
tests/test_main.py::TestMain::test_get_selected_roles_multiple_list PASSED                                      [ 47%]
tests/test_main.py::TestMain::test_missing_app_from_config PASSED                                               [ 48%]
tests/test_main.py::TestMain::test_missing_role_from_config PASSED                                              [ 50%]
tests/test_main.py::TestMain::test_parse_role_arn_base_path PASSED                                              [ 51%]
tests/test_main.py::TestMain::test_parse_role_arn_extended_path PASSED                                          [ 52%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_authenticator_enrollment PASSED                  [ 53%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_build_factor_name_email PASSED                   [ 55%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_build_factor_name_hardware PASSED                [ 56%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_build_factor_name_push PASSED                    [ 57%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_build_factor_name_sms PASSED                     [ 58%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_build_factor_name_totp PASSED                    [ 60%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_build_factor_name_unknown PASSED                 [ 61%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_build_factor_name_webauthn_registered PASSED     [ 62%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_build_factor_name_webauthn_unregistered PASSED   [ 64%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_build_factor_name_webauthn_unregistered_with_authenticator_name PASSED [ 65%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_check_push_result PASSED                         [ 66%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_choose_bad_factor_totp PASSED                    [ 67%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_choose_factor_push PASSED                        [ 69%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_choose_factor_sms PASSED                         [ 70%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_choose_factor_totp PASSED                        [ 71%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_choose_factor_webauthn PASSED                    [ 73%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_choose_non_number_factor_totp PASSED             [ 74%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_get_headers PASSED                               [ 75%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_get_saml_response PASSED                         [ 76%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_get_state_token PASSED                           [ 78%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_get_username_password_creds PASSED               [ 79%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_login_input_mfa_challenge PASSED                 [ 80%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_login_send_email PASSED                          [ 82%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_login_send_push PASSED                           [ 83%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_login_send_sms PASSED                            [ 84%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_login_username_password PASSED                   [ 85%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_missing_password PASSED                          [ 87%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_missing_saml_response PASSED                     [ 88%]
tests/test_okta_classic_client.py::TestOktaClassicClient::test_passed_username PASSED                           [ 89%]
tests/test_okta_identity_engine_client.py::TestOktaIdentityEngineClient::test_auth_session PASSED               [ 91%]
tests/test_okta_identity_engine_client.py::TestOktaIdentityEngineClient::test_get_headers PASSED                [ 92%]
tests/test_okta_identity_engine_client.py::TestOktaIdentityEngineClient::test_get_user_tokens PASSED            [ 93%]
tests/test_okta_identity_engine_client.py::TestOktaIdentityEngineClient::test_saml_response PASSED              [ 94%]
tests/test_okta_identity_engine_client.py::TestOktaIdentityEngineClient::test_start_device_flow PASSED          [ 96%]
tests/test_registered_authenticators.py::TestConfig::test_add_authenticator_sanity PASSED                       [ 97%]
tests/test_registered_authenticators.py::TestConfig::test_file_creation_post_init PASSED                        [ 98%]
tests/test_registered_authenticators.py::TestConfig::test_get_authenticator_user_sanity PASSED                  [100%]

========================================================================= 78 passed in 1.52s =========================================================================

```

## Screenshots (if appropriate):

N/A.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
