### PR TITLE
Make the use of system keychain optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ A configuration wizard will prompt you to enter the necessary configuration para
 - aws_default_duration = This is optional. Lifetime for temporary credentials, in seconds. Defaults to 1 hour (3600)
 - app_url - If using 'appurl' setting for gimme_creds_server, this sets the url to the aws application configured in Okta. It is typically something like <https://something.okta[preview].com/home/amazon_aws/app_instance_id/something>
 - okta_username - use this username to authenticate
+- enable_keychain - enable the use of the system keychain to store the user's password
 - preferred_mfa_type - automatically select a particular  device when prompted for MFA:
   - push - Okta Verify App push or DUO push (depends on okta supplied provider type)
   - token:software:totp - OTP using the Okta Verify App

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -460,6 +460,9 @@ class GimmeAWSCreds(object):
         config.get_args()
         self._cache['conf_dict'] = config.get_config_dict()
 
+        if config.disable_keychain is True:
+            self.conf_dict['enable_keychain'] = False
+
         for value in self.envvar_list:
             if self.ui.environ.get(value):
                 key = self.envvar_conf_map.get(value, value).lower()
@@ -566,6 +569,7 @@ class GimmeAWSCreds(object):
                 self.okta_org_url,
                 self.config.verify_ssl_certs,
                 self.device_token,
+                self.conf_dict.get('enable_keychain', True)
             )
 
             if self.config.username is not None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,7 +38,8 @@ class TestConfig(unittest.TestCase):
             action_store_json_creds=False,
             action_setup_fido_authenticator=False,
             open_browser=False,
-            force_classic=False
+            force_classic=False,
+            disable_keychain=False
         ),
     )
     def test_get_args_username(self, mock_arg):


### PR DESCRIPTION
## Description
Added a new config option (`enable_keychain`) and CLI parameter (`--disable-keychain`).  `enable_keychain` defaults to TRUE so that existing behavior is not affected.  If `--disable-keychain` is used or `enable_keychain = False`, the system keychain will not be used and the user will always be prompted for their password.

## Related Issue
#212

## Motivation and Context
Some organizations may want to avoid the storage of user credentials and force the user to input their password on every use.

## How Has This Been Tested?
tested on macOS 13.6 with Python 3.11.6

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
