### PR TITLE
Introduce pyproject.toml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN apk --update add libgcc
 ENV PACKAGES="gcc musl-dev python3-dev libffi-dev openssl-dev cargo"
 
 RUN apk --update add $PACKAGES \
-    && pip install --upgrade pip setuptools-rust \
-    && python setup.py install \
+    && python -m pip install .\
     && apk del --purge $PACKAGES
 
 ENTRYPOINT ["/usr/local/bin/gimme-aws-creds"]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ __OR__
 Install the gimme-aws-creds package if you have already cloned the source:
 
 ```bash
-python3 setup.py install
+python -m pip install .
 ```
 
 __OR__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-rust", "gimme_aws_creds"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Using a more modern setuptools build pipeline, removing warnings in the generated files:

```
/usr/local/bin/gimme-aws-creds:4: DeprecationWarning:
pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  __import__('pkg_resources').run_script('gimme-aws-creds==2.7.2', 'gimme-aws-creds')
```

## Description
In this change we introduce a more modern version of packaging this project by using a `pyproject.toml`.
The changes is the most limited change we could see.  Maybe you want to be done more?

## Motivation and Context
The docker images and local install (on some setups) generated the above warning.

## How Has This Been Tested?
* build locally and run
* build docker file see that the warning mentioned above is gone.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
