### PR TITLE
feature:Allow configuration of a preferred_mfa_provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,10 @@ A configuration wizard will prompt you to enter the necessary configuration para
   - web - DUO uses localhost webbrowser to support push|call|passcode
   - passcode - DUO uses `OKTA_MFA_CODE` or `--mfa-code` if set, or prompts user for passcode(OTP).
   - claims_provider - DUO Universal Prompt
+- preferred_mfa_provider - (optional) automatically select a particular provider when prompted for MFA:
+  - GOOGLE
+  - OKTA
+  - DUO
 - duo_universal_factor - (optional) Configure which type of factor to use with Duo Universal Prompt. Must be one of (case-sensitive):
   - `Duo Push` (default)
   - `Passcode`

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -583,6 +583,9 @@ class GimmeAWSCreds(object):
             if self.conf_dict.get('preferred_mfa_type'):
                 okta.set_preferred_mfa_type(self.conf_dict['preferred_mfa_type'])
 
+            if self.conf_dict.get('preferred_mfa_provider'):
+                okta.set_preferred_mfa_provider(self.conf_dict['preferred_mfa_provider'])
+
             if self.conf_dict.get('duo_universal_factor'):
                 okta.set_duo_universal_factor(self.conf_dict.get('duo_universal_factor'))
 

--- a/gimme_aws_creds/okta_classic.py
+++ b/gimme_aws_creds/okta_classic.py
@@ -65,6 +65,7 @@ class OktaClassicClient(object):
         self._username = None
         self._password = None
         self._preferred_mfa_type = None
+        self._preferred_mfa_provider = None
         self._duo_universal_factor = 'Duo Push'
         self._mfa_code = None
         self._remember_device = None
@@ -104,6 +105,9 @@ class OktaClassicClient(object):
 
     def set_preferred_mfa_type(self, preferred_mfa_type):
         self._preferred_mfa_type = preferred_mfa_type
+
+    def set_preferred_mfa_provider(self, preferred_mfa_provider):
+        self._preferred_mfa_provider = preferred_mfa_provider
 
     def set_mfa_code(self, mfa_code):
         self._mfa_code = mfa_code
@@ -836,6 +840,19 @@ class OktaClassicClient(object):
             # prompting to select another.
             if not preferred_factors:
                 self.ui.notify('Preferred factor type of {} not available.'.format(self._preferred_mfa_type))
+
+        if self._preferred_mfa_provider is not None:
+            preferred_factors_with_preferred_provider = list(
+                filter(lambda item: item['provider'] == self._preferred_mfa_provider, preferred_factors)
+            )
+            # If filtering for the preferred provider yields no results, announce it,
+            # but don't update the list of preferred factors.
+            if preferred_factors and not preferred_factors_with_preferred_provider:
+                self.ui.notify('Preferred factor provider of {} not available. Will use available factors.'.format(
+                    self._preferred_mfa_provider
+                ))
+            else:
+                preferred_factors = preferred_factors_with_preferred_provider
 
         if len(preferred_factors) == 1:
             factor_name = self._build_factor_name(preferred_factors[0])


### PR DESCRIPTION
## Description
Allows for configuration of a preferred mfa provider which is used to more precisely select an available preferred mfa factor by filtering the list of available factors by provider in addition to type. This allows, for instance, a user to have setup both Google totp and Okta push and to have a preferred default used by gimme-aws-creds; currently in this situation, the user must select their preferred mfa factor at runtime as gimme-aws-creds will see both available and default to prompting the user to select one.

## Related Issue
https://github.com/Nike-Inc/gimme-aws-creds/issues/445

## Motivation and Context
In order to give myself options, I have both Google Authenticator and Okta Verify setup. In the past, I have disabled Okta Verify so that gimme-aws-creds only has one totp mfa to find, but this seems like an unnecessary concession.

## How Has This Been Tested?
While using an Okta account with both Google Authenticator and Okta Verify setup:
1) With `preferred_mfa_type = token:software:totp` and  `preferred_mfa_provider = GOOGLE` in the global config, the user is prompted for an authentication token from Google.
2) With `preferred_mfa_type = token:software:totp` and  `preferred_mfa_provider = OKTA` in the global config, the user is prompted for an authentication token from Okta.
3) With `preferred_mfa_type = token:software:totp` and  `preferred_mfa_provider = GOOGLE` in an account configuration, the use is prompted for an authentication token from Google.
4) With `preferred_mfa_type = token:software:totp` and  `preferred_mfa_provider = OKTA` in an account config, the user is prompted for an authentication token from Okta.
5) With neither `preferred_mfa_type` or `preferred_mfa_provider` configured, the user is prompted to select a factor as they were previously.
5) With `preferred_mfa_type = token:software:totp` and `preferred_mfa_provider` unset, the user is prompted to select a factor as they were previously when a preferred type is configured.

I do not use DUO, and I am unaware of which other combinations of factors might be affected by this. I specifically included logic to avoid filtering out all potential factors if none match the preferred provider to minimize potential confusion.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
