### PR TITLE
Add sessionToken to dict where step-up code expects it

### DIFF
--- a/gimme_aws_creds/duo_universal.py
+++ b/gimme_aws_creds/duo_universal.py
@@ -68,7 +68,8 @@ class OktaDuoUniversal:
                     "username": okta_profile_login,
                     "session": self.session.cookies['sid'],
                     "device_token": self.session.cookies['DT']
-                }
+                },
+                'sessionToken': self.session.cookies['sid']
             },
         }
 

--- a/tests/test_duo_universal_client.py
+++ b/tests/test_duo_universal_client.py
@@ -4,9 +4,9 @@ from unittest.mock import Mock
 
 import requests
 import responses
-from tests import read_fixture
 
 from gimme_aws_creds.duo_universal import OktaDuoUniversal
+from tests import read_fixture
 from tests.user_interface_mock import MockUserInterface
 
 
@@ -135,7 +135,8 @@ class TestDuoUniversalClient(unittest.TestCase):
                     'username': self.OKTA_LOGIN,
                     'session': self.OKTA_SID_VALUE,
                     'device_token': self.OKTA_DT_VALUE
-                }
+                },
+                'sessionToken': 'oktasidvalue',
             },
         }
 
@@ -157,7 +158,8 @@ class TestDuoUniversalClient(unittest.TestCase):
                     'username': self.OKTA_LOGIN,
                     'session': self.OKTA_SID_VALUE,
                     'device_token': self.OKTA_DT_VALUE
-                }
+                },
+                'sessionToken': 'oktasidvalue',
             },
         }
 
@@ -180,7 +182,8 @@ class TestDuoUniversalClient(unittest.TestCase):
                     'username': self.OKTA_LOGIN,
                     'session': self.OKTA_SID_VALUE,
                     'device_token': self.OKTA_DT_VALUE
-                }
+                },
+                'sessionToken': 'oktasidvalue',
             },
         }
 


### PR DESCRIPTION
## Description

Sometimes, Okta requires a step-up authentication when accessing the AWS Okta application. The Duo Universal prompt support worked in the case where step-up was not required, but returned a session data structure that the step-up handling code did not expect. I've changed the Duo Universal Prompt auth to return `sessionToken` where `OktaClassicClient.get_saml_response()` expects to find it for use in step-up authentication.

## Related Issue
#447 

## Motivation and Context
Authentication doesn't work if Okta requires step-up auth with Duo Universal Prompt enabled.

## How Has This Been Tested?
We had a few people at our org encounter this issue after disabling Duo's traditional prompt in our Okta tenant. I found the additional step-up authentication code path when debugging with them, and realized the data structure I had returned from Univeral Prompt implementation was different than the step-up code expected. Adding the session token at the expected key resolved the issue for them.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
