### PR TITLE
Only skip using the DT cookie when connecting to an OIE domain

### DIFF
--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -77,6 +77,7 @@ class GimmeAWSCreds(object):
             os.path.join(self.FILE_ROOT, '.aws', 'credentials')
         )
         self._cache = {}
+        self.skip_DT = False
 
     #  this is modified code from https://github.com/nimbusscale/okta_aws_login
     def _write_aws_creds(self, profile, access_key, secret_key, token, expiration, aws_config=None):
@@ -525,6 +526,8 @@ class GimmeAWSCreds(object):
                 if self.config.force_classic is True or self.conf_dict.get('force_classic') is True:
                     self.ui.message('Okta Classic login flow enabled')
                     ret = 'classic'
+                    # Skip Device Token registration
+                    self.skip_DT = True
                 else:
                     if not self.conf_dict.get('client_id'):
                         raise errors.GimmeAWSCredsError('OAuth Client ID is required for Okta Identity Engine domains.  Try running --config again.')
@@ -606,7 +609,7 @@ class GimmeAWSCreds(object):
 
     @property
     def device_token(self):
-        if self.config.action_register_device is True or self.conf_dict.get('force_classic') is True:
+        if self.config.action_register_device is True or self.skip_DT is True:
             self.conf_dict['device_token'] = None
 
         return self.conf_dict.get('device_token')
@@ -943,7 +946,7 @@ class GimmeAWSCreds(object):
 
     def handle_action_register_device(self):
         # Capture the Device Token and write it to the config file
-        if self.okta_platform == "classic" and (self.conf_dict.get('force_classic') is not True) and ( not self.device_token or self.config.action_register_device is True ):
+        if self.okta_platform == "classic" and self.skip_DT is False and ( not self.device_token or self.config.action_register_device is True ):
             if not self.config.action_register_device:
                 self.ui.notify('\n*** No device token found in configuration file, it will be created.')
                 self.ui.notify('*** You may be prompted for MFA more than once for this run.\n')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The recent changes to skip sending the DT cookie in force_classic mode also affected Okta Classic domains.  This change ensures that DT cookie only gets skipped when connecting to an OIE domain.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
