### PR TITLE
Check config options as Booleans instead of strings

### DIFF
--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -818,7 +818,7 @@ class GimmeAWSCreds(object):
             account = self._get_account_name(naming_data['account'], role, resolve_alias)
             role_name = naming_data['role']
             path = naming_data['path']
-            if include_path == 'True':
+            if include_path is True:
                 role_name = ''.join([path, role_name])
             profile_name = '-'.join([account,
                                      role_name])
@@ -827,7 +827,7 @@ class GimmeAWSCreds(object):
         return profile_name
 
     def _get_account_name(self, account, role, resolve_alias):
-        if resolve_alias == "False":
+        if resolve_alias is False:
             return account
         account_alias = self._get_alias_from_friendly_name(role.friendly_account_name)
         return account_alias or account

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -197,8 +197,8 @@ class TestMain(unittest.TestCase):
                        friendly_account_name='Account: my-org-master (123456789012)',
                        friendly_role_name='administrator/administrator')
         cred_profile = 'acc-role'
-        resolve_alias = 'True'
-        include_path = 'False'
+        resolve_alias = True
+        include_path = False
         self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role), "my-org-master-administrator")
 
     def test_get_profile_accrole_name_do_not_resolve_alias_do_not_include_paths(self):
@@ -210,8 +210,8 @@ class TestMain(unittest.TestCase):
                        friendly_account_name='Account: my-org-master (123456789012)',
                        friendly_role_name='administrator/administrator')
         cred_profile = 'acc-role'
-        resolve_alias = 'False'
-        include_path = 'False'
+        resolve_alias = False
+        include_path = False
         self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
                          "123456789012-administrator")
 
@@ -224,8 +224,8 @@ class TestMain(unittest.TestCase):
                        friendly_account_name='Account: my-org-master (123456789012)',
                        friendly_role_name='administrator/administrator')
         cred_profile = 'acc-role'
-        resolve_alias = 'False'
-        include_path = 'True'
+        resolve_alias = False
+        include_path = True
         self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
                          "123456789012-/some/long/extended/path/administrator")
 
@@ -238,8 +238,8 @@ class TestMain(unittest.TestCase):
                        friendly_account_name='Account: my-org-master (123456789012)',
                        friendly_role_name='administrator/administrator')
         cred_profile = 'role'
-        resolve_alias = 'False'
-        include_path = 'True'
+        resolve_alias = False
+        include_path = True
         self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
                          'administrator')
 
@@ -252,8 +252,8 @@ class TestMain(unittest.TestCase):
                        friendly_account_name='Account: my-org-master (123456789012)',
                        friendly_role_name='administrator/administrator')
         cred_profile = 'acc'
-        resolve_alias = 'True'
-        include_path = 'True'
+        resolve_alias = True
+        include_path = True
         self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
                          'my-org-master')
 
@@ -266,8 +266,8 @@ class TestMain(unittest.TestCase):
                        friendly_account_name='Account: my-org-master (123456789012)',
                        friendly_role_name='administrator/administrator')
         cred_profile = 'acc'
-        resolve_alias = 'False'
-        include_path = 'True'
+        resolve_alias = False
+        include_path = True
         self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
                          '123456789012')
 
@@ -280,8 +280,8 @@ class TestMain(unittest.TestCase):
                        friendly_account_name='Account: my-org-master (123456789012)',
                        friendly_role_name='administrator/administrator')
         cred_profile = 'default'
-        resolve_alias = 'False'
-        include_path = 'True'
+        resolve_alias = False
+        include_path = True
         self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
                          'default')
 
@@ -294,7 +294,7 @@ class TestMain(unittest.TestCase):
                        friendly_account_name='Account: my-org-master (123456789012)',
                        friendly_role_name='administrator/administrator')
         cred_profile = 'foo'
-        resolve_alias = 'False'
-        include_path = 'True'
+        resolve_alias = False
+        include_path = True
         self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
                          'foo')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Part of the code changes included with #440 was converting the True/False strings read in from the config file to Booleans.  However, some of the code still expected those values to be strings.  This change fixes the two remaining spots that expected them to be strings.

## Related Issue
#459 

## How Has This Been Tested?
Tested on macOS w/ Python 3.12 - all tests have been updated


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
