### PR TITLE
Keep original `force_classic` value during profile inheritance

### DIFF
--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -201,23 +201,22 @@ class Config(object):
                 profile_config[key] = True
             elif profile_config[key] == 'False':
                 profile_config[key] = False
-        
-        # Empty string in force_classic should be handled as True - this makes sure that migrating from Classic to OIE is seamless
-        if profile_config.get('force_classic') == '' or profile_config.get('force_classic') is None:
-            profile_config['force_classic'] = True
 
         if "inherits" in profile_config.keys() and include_inherits:
             self.ui.message("Using inherited config: " + profile_config["inherits"])
             if profile_config["inherits"] not in config:
                 raise errors.GimmeAWSCredsError(self.conf_profile + " inherits from " + profile_config["inherits"] + ", but could not find " + profile_config["inherits"])
-            combined_config = {
+            profile_config = {
                 **self._handle_config(config, dict(config[profile_config["inherits"]])),
                 **profile_config,
             }
-            del combined_config["inherits"]
-            return combined_config
-        else:
-            return profile_config
+            del profile_config["inherits"]
+
+        # Empty string in force_classic should be handled as True - this makes sure that migrating from Classic to OIE is seamless
+        if profile_config.get('force_classic') == '' or profile_config.get('force_classic') is None:
+            profile_config['force_classic'] = True
+
+        return profile_config
 
     def get_config_dict(self, include_inherits = True):
         """returns the conf dict from the okta config file"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -122,6 +122,35 @@ aws_rolename = myrole
             "force_classic": True
         })
 
+    def test_read_nested_config_inherited_no_force_classic(self):
+        """Test to make sure getting config works when inherited"""
+        test_ui = MockUserInterface(argv = [
+            "--profile",
+            "myprofile",
+        ])
+        with open(test_ui.HOME + "/.okta_aws_login_config", "w") as config_file:
+            config_file.write("""
+[mybase-level1]
+client_id = bar
+[mybase-level2]
+inherits = mybase-level1
+aws_appname = baz
+force_classic = False
+[myprofile]
+inherits = mybase-level2
+client_id = foo
+aws_rolename = myrole
+""")
+        config = Config(gac_ui=test_ui, create_config=False)
+        config.conf_profile = "myprofile"
+        profile_config = config.get_config_dict()
+        self.assertEqual(profile_config, {
+            "client_id": "foo",
+            "aws_appname": "baz",
+            "aws_rolename": "myrole",
+            "force_classic": False
+        })
+
     def test_fail_if_profile_not_found(self):
         """Test to make sure missing Default fails properly"""
         test_ui = MockUserInterface(argv=[])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When inheriting a profile stating `force_classic = False` this value is getting overridden by the default value `force_classic = True` if the child profile does not explicitly set `force_classic = False` as well

## Related Issue
fixes #463

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Added a test 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
