### PR TITLE
Disable `ctap-keyring-device` on Windows with Python3.10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Okta is a registered trademark of Okta, Inc. and this tool has no affiliation wi
 
 Python 3.7+
 
+####  A Note on Python 3.10+ Compatibility on Windows
+
+`gimme-aws-creds` depends on the [ctap-keyring-device](https://pypi.org/project/ctap-keyring-device/) library for WebAuthn support.  All of the released versions of ctap-keyring-device require [winRT](https://pypi.org/project/winrt/) on Windows, which only works on Python 3.9 and lower and is no longer maintained. Until a version of ctap-keyring-device that supports `winSDK` (the replacement for winRT) is released to PyPi, or some other solution is found, WebAuthn support will not be available for people running Python 3.10+ on Windows.
+
 ### Optional
 
 [Gimme-creds-lambda](https://github.com/Nike-Inc/gimme-aws-creds/tree/master/lambda) can be used as a proxy to the Okta APIs needed by gimme-aws-creds.  This removes the requirement of an Okta API key.  Gimme-aws-creds authenticates to gimme-creds-lambda using OpenID Connect and the lambda handles all interactions with the Okta APIs.  Alternately, you can set the `OKTA_API_KEY` environment variable and the `gimme_creds_server` configuration value to 'internal' to call the Okta APIs directly from gimme-aws-creds.

--- a/gimme_aws_creds/__init__.py
+++ b/gimme_aws_creds/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['config', 'aws', 'main', 'ui', 'common', 'default', 'duo', 'errors', 'okta_classic', 'okta_identity_engine', 'registered_authenticators', 'u2f', 'webauthn']
-version = '2.8.1.1'
+version = '2.8.2-pre'

--- a/gimme_aws_creds/dummy_webauthn.py
+++ b/gimme_aws_creds/dummy_webauthn.py
@@ -1,0 +1,60 @@
+"""
+Copyright 2024-present Nike, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and* limitations under the License.*
+"""
+
+
+from . import errors
+
+class FakeAssertion(object):
+    def __init__(self):
+        self.signature = b'fake'
+        self.auth_data = b'fake'
+
+
+class WebAuthnClient(object):
+    """ Dummy WebAuthnClient class - needed until ctap-keyring-device is updated to support Python 3.10+ on Windows"""
+    def __init__(self, ui, okta_org_url, challenge, credential_id=None, timeout_ms=30_000):
+        return None
+
+    def locate_device(self):
+        return None
+
+    def on_keepalive(self, status):
+        return None
+
+    def verify(self):
+        raise errors.GimmeAWSCredsError(
+                "WebAuthn devices not supported on this platform", 2
+            )
+        
+    def _verify(self, client):
+        return None
+
+    def make_credential(self, user):
+        raise errors.GimmeAWSCredsError(
+                "WebAuthn devices not supported on this platform", 2
+            )
+
+    def _make_credential(self, client, user):
+        return None
+
+    def _run_in_thread(self, method, *args, **kwargs):
+        return None
+
+    def _get_pin_from_client(self, client):
+        raise errors.GimmeAWSCredsError(
+                "WebAuthn devices not supported on this platform", 2
+            )
+    @staticmethod
+    def _get_user_verification_requirement_from_client(client):
+        raise errors.GimmeAWSCredsError(
+                "WebAuthn devices not supported on this platform", 2
+            )

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -17,6 +17,7 @@ import json
 import os
 import re
 import sys
+import platform
 import concurrent.futures
 
 # extras
@@ -510,7 +511,7 @@ class GimmeAWSCreds(object):
             self.okta_org_url + '/.well-known/okta-organization',
             headers={
                 'Accept': 'application/json',
-                'User-Agent': "gimme-aws-creds {}".format(version)
+                'User-Agent': "gimme-aws-creds {};{};{}".format(version, sys.platform, platform.python_version())
             },
             timeout=30
         )

--- a/gimme_aws_creds/okta_classic.py
+++ b/gimme_aws_creds/okta_classic.py
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and* limitations
 """
 import base64
 import sys
+import platform
 import copy
 import re
 import socket
@@ -292,7 +293,7 @@ class OktaClassicClient(object):
     def _get_headers():
         """sets the default headers"""
         headers = {
-            'User-Agent': "gimme-aws-creds {}".format(version),
+            'User-Agent': "gimme-aws-creds {};{};{}".format(version, sys.platform, platform.python_version()),
             'Accept': 'application/json',
             'Content-Type': 'application/json',
         }

--- a/gimme_aws_creds/okta_classic.py
+++ b/gimme_aws_creds/okta_classic.py
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and* limitations under the License.*
 """
 import base64
+import sys
 import copy
 import re
 import socket
@@ -30,11 +31,18 @@ from keyring.errors import PasswordDeleteError
 from requests.adapters import HTTPAdapter, Retry
 
 from gimme_aws_creds.u2f import FactorU2F
-from gimme_aws_creds.webauthn import WebAuthnClient, FakeAssertion
+
+# avoid importing ctap-keyring-device on Windows until it supports Python 3.10+
+if sys.platform == "win32" and sys.version_info >= (3, 10):
+    from gimme_aws_creds.dummy_webauthn import WebAuthnClient, FakeAssertion
+else:
+    from gimme_aws_creds.webauthn import WebAuthnClient, FakeAssertion
+
 from . import errors, ui, version, duo
 from .duo_universal import OktaDuoUniversal
 from .errors import GimmeAWSCredsMFAEnrollStatus
 from .registered_authenticators import RegisteredAuthenticators
+
 
 
 class OktaClassicClient(object):
@@ -622,7 +630,11 @@ class OktaClassicClient(object):
         elif factor['factorType'] == 'u2f':
             return self._login_input_webauthn_challenge(state_token, factor)
         elif factor['factorType'] == 'webauthn':
-            return self._login_input_webauthn_challenge(state_token, factor)
+            # Block webauthn until ctap-kering-device is updated to support Python 3.10+ on Windows
+            if sys.platform == "win32" and sys.version_info >= (3, 10):
+                raise errors.GimmeAWSCredsError("WebAuthn devices not supported on this platform", 2)
+            else:
+                return self._login_input_webauthn_challenge(state_token, factor)
         elif factor['factorType'] == 'token:hardware':
             return self._login_input_mfa_challenge(state_token, factor['_links']['verify']['href'])
         elif factor['factorType'] == 'claims_provider':

--- a/gimme_aws_creds/okta_identity_engine.py
+++ b/gimme_aws_creds/okta_identity_engine.py
@@ -9,6 +9,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and* limitations under the License.*
 """
+import platform
 import time
 import webbrowser
 import jwt
@@ -200,7 +201,7 @@ class OktaIdentityEngine(object):
     def _get_headers():
         """sets the default headers"""
         headers = {
-            'User-Agent': "gimme-aws-creds {}".format(version),
+            'User-Agent': "gimme-aws-creds {};{};{}".format(version, sys.platform, platform.python_version()),
             'Accept': 'application/json'
         }
         return headers

--- a/gimme_aws_creds/okta_identity_engine.py
+++ b/gimme_aws_creds/okta_identity_engine.py
@@ -9,6 +9,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and* limitations under the License.*
 """
+import sys
 import platform
 import time
 import webbrowser

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ keyring>=21.4.0
 requests>=2.25.0,<3.0.0
 fido2>=0.9.1,<0.10.0
 okta>=2.9.0,<3.0.0
-ctap-keyring-device==1.0.6
+ctap-keyring-device==1.0.6; sys_platform == "win32" and python_version < "3.10"
 pyjwt>=2.4.0,<3.0.0
 urllib3>=1.26.0,<2.0.0
 html5lib>=1.1,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ keyring>=21.4.0
 requests>=2.25.0,<3.0.0
 fido2>=0.9.1,<0.10.0
 okta>=2.9.0,<3.0.0
-ctap-keyring-device==1.0.6; sys_platform == "win32" and python_version < "3.10"
+ctap-keyring-device==1.0.6; (sys_platform == "win32" and python_version < "3.10") or sys_platform != "win32"
 pyjwt>=2.4.0,<3.0.0
 urllib3>=1.26.0,<2.0.0
 html5lib>=1.1,<2.0.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='gimme_aws_creds',
-    version='2.8.1.1',
+    version='2.8.2-pre',
     install_requires=requirements,
     author='Eric Pierce',
     author_email='eric.pierce@nike.com',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
All of the released versions of [ctap-keyring-device](https://pypi.org/project/ctap-keyring-device/) require [winRT](https://pypi.org/project/winrt/) on Windows, which does not support Python 3.10+ Support for the replacement library (winSDK) was added to ctap-keyring-device in 2022, but it still hasn't been released and the project appears to be abandoned.  We will likely need to fork the project to release a new version, but that's a longer-term project.  My first priority is making it possible to install the latest version of gimme-aws-creds on Windows with a Python version newer than 3.9.

The obvious downside of not having access to the ctap-keyring-device library is that WebAuthn support will not be available in Windows with Python 3.10+, but all other factors will be available.  This change *only* affects Windows running Python 3.10+ - all other platforms/Python versions retain WebAuthn functionality.

## Related Issue
#435 
#430 
#337 
#320 

## Motivation and Context
Downgrading Python to use gimme-aws-creds isn't a valid option for Windows users. Binaries for the latest version of Python 3.9 are no longer available for Windows anyway.  This makes it possible to use the latest version without support WebAuthn factors

## How Has This Been Tested?
Tested on Windows 11 with Python 3.9, 3.12 and 3.13
WebAuthn support tested an working on 
* Windows 11 - Python 3.9
* macOS - Python 3.12
* Linux - Python 3.7, 3.8, 3.9, 3.10

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
