### PR TITLE
Feature: Implement the ability to select all roles in the role selection screen with "a" or "all"

### DIFF
--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -449,7 +449,6 @@ class GimmeAWSCreds(object):
                 continue
 
             if selections:
-                self.ui.message('Selections: {}'.format(selections))
                 return selections
 
         return set()

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -420,25 +420,29 @@ class GimmeAWSCreds(object):
         for _ in range(max_retries):
             selections = set()
             error = False
+            input_values = self.ui.input('Selections (comma separated; "A" for all profiles): ').split(',')
 
-            for value in self.ui.input('Selections (comma separated): ').split(','):
-                value = value.strip()
+            if 'a' in input_values or 'A' in input_values:
+                selections = set(range(min_int, max_int))
+            else:
+                for value in input_values:
+                    value = value.strip()
 
-                if not value:
-                    continue
+                    if not value:
+                        continue
 
-                try:
-                    selection = int(value)
-                except ValueError:
-                    self.ui.warning('Invalid selection {}, must be an integer value.'.format(repr(value)))
-                    error = True
-                    continue
+                    try:
+                        selection = int(value)
+                    except ValueError:
+                        self.ui.warning('Invalid selection {}, must be an integer value.'.format(repr(value)))
+                        error = True
+                        continue
 
-                if min_int <= selection <= max_int:
-                    selections.add(value)
-                else:
-                    self.ui.warning(
-                        'Selection {} out of range <{}, {}>'.format(repr(selection), min_int, max_int))
+                    if min_int <= selection <= max_int:
+                        selections.add(value)
+                    else:
+                        self.ui.warning(
+                            'Selection {} out of range <{}, {}>'.format(repr(selection), min_int, max_int))
 
             if error:
                 continue

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -420,10 +420,11 @@ class GimmeAWSCreds(object):
         for _ in range(max_retries):
             selections = set()
             error = False
-            input_values = self.ui.input('Selections (comma separated; "A" for all profiles): ').split(',')
+            input_values = self.ui.input('Selections (comma separated; "[A]" for all profiles): ').lower().split(',')
 
-            if 'a' in input_values or 'A' in input_values:
+            if 'a' in input_values or 'all' in input_values:
                 selections = set(range(min_int, max_int))
+                self.ui.message("Generating credentials for profile indices {} to {} ".format(min_int, max_int))
             else:
                 for value in input_values:
                     value = value.strip()
@@ -434,7 +435,7 @@ class GimmeAWSCreds(object):
                     try:
                         selection = int(value)
                     except ValueError:
-                        self.ui.warning('Invalid selection {}, must be an integer value.'.format(repr(value)))
+                        self.ui.warning('Invalid selection {}, must be an integer value, or "A" for all profiles'.format(repr(value)))
                         error = True
                         continue
 

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -423,7 +423,7 @@ class GimmeAWSCreds(object):
             input_values = self.ui.input('Selections (comma separated; specify "A" for all profiles): ').lower().split(',')
 
             if 'a' in input_values or 'all' in input_values:
-                selections = set(range(min_int, max_int))
+                selections = set(range(min_int, max_int+1))
                 self.ui.message("Generating credentials for profile indices {} to {} ".format(min_int, max_int))
             else:
                 for value in input_values:
@@ -449,6 +449,7 @@ class GimmeAWSCreds(object):
                 continue
 
             if selections:
+                self.ui.message('Selections: {}'.format(selections))
                 return selections
 
         return set()

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -420,7 +420,7 @@ class GimmeAWSCreds(object):
         for _ in range(max_retries):
             selections = set()
             error = False
-            input_values = self.ui.input('Selections (comma separated; "[A]" for all profiles): ').lower().split(',')
+            input_values = self.ui.input('Selections (comma separated; specify "A" for all profiles): ').lower().split(',')
 
             if 'a' in input_values or 'all' in input_values:
                 selections = set(range(min_int, max_int))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,12 +47,26 @@ class TestMain(unittest.TestCase):
         self.assertRaises(errors.GimmeAWSCredsExitBase, creds._choose_roles, self.APP_INFO)
         self.assertRaises(errors.GimmeAWSCredsExitBase, creds._choose_app, self.AWS_INFO)
 
-    @patch('builtins.input', return_value='a')
-    def test_choose_roles_app_a(self, mock):
+    @patch('builtins.input', return_value='b')
+    def test_choose_roles_app_b(self, mock):
         creds = GimmeAWSCreds()
         self.assertRaises(errors.GimmeAWSCredsExitBase, creds._choose_roles, self.APP_INFO)
         self.assertRaises(errors.GimmeAWSCredsExitBase, creds._choose_app, self.AWS_INFO)
 
+    @patch('builtins.input', return_value='all')
+    def test_choose_roles_app_select_all(self, mock):
+        creds = GimmeAWSCreds()
+        selections = creds._choose_roles(self.APP_INFO)
+        expected_selections = {self.APP_INFO[0].role, self.APP_INFO[1].role}
+        self.assertEqual(selections, expected_selections)
+        
+    @patch('builtins.input', return_value='a')
+    def test_choose_roles_app_select_all_a(self, mock):
+        creds = GimmeAWSCreds()
+        selections = creds._choose_roles(self.APP_INFO)
+        expected_selections = {self.APP_INFO[0].role, self.APP_INFO[1].role}
+        self.assertEqual(selections, expected_selections)
+        
     def test_get_selected_app_from_config_0(self):
         creds = GimmeAWSCreds()
 
@@ -96,10 +110,10 @@ class TestMain(unittest.TestCase):
         selections = creds._get_selected_roles(['test1', 'test2'], self.APP_INFO)
         self.assertEqual(selections, {'test1', 'test2'})
 
-    def test_get_selected_roles_all(self):
+    def test_get_selected_roles_a(self):
         creds = GimmeAWSCreds()
 
-        selections = creds._get_selected_roles('all', self.APP_INFO)
+        selections = creds._get_selected_roles('a', self.APP_INFO)
         self.assertEqual(selections, {'test1', 'test2'})
 
     @patch('builtins.input', return_value='0')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -110,10 +110,10 @@ class TestMain(unittest.TestCase):
         selections = creds._get_selected_roles(['test1', 'test2'], self.APP_INFO)
         self.assertEqual(selections, {'test1', 'test2'})
 
-    def test_get_selected_roles_a(self):
+    def test_get_selected_roles_all(self):
         creds = GimmeAWSCreds()
 
-        selections = creds._get_selected_roles('a', self.APP_INFO)
+        selections = creds._get_selected_roles('all', self.APP_INFO)
         self.assertEqual(selections, {'test1', 'test2'})
 
     @patch('builtins.input', return_value='0')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Per feature request #472 this PR contains code to implement the logic to prompt users for "a" or "all" in the role selection screen to select all roles available to them.

## Description
<!--- Describe your changes in detail -->
The following changes were implemented

In main.py, the [_get_user_int_selections_many](https://github.com/its-mirus-lu/gimme-aws-creds/blob/0eeec0c0b8829f02477a884ec60207b5cfbb87b0/gimme_aws_creds/main.py#L419C5-L454C21) was modified: 
1. Modified 'Selections (comma separated)' to 'Selections (comma separated; specify "A" for all profiles)' in _get_user_int_selections_many
2. Modified logic in _get_user_int_selections_many method to detect whether 'a' or 'all' is specified in the user inputs
3. Populate selections set in _get_user_int_selections_many method with range of values from min_int to max_int

Two test cases were added to validate the implementation:
* def test_choose_roles_app_select_all(self, mock):
* def test_choose_roles_app_select_all_a(self, mock):

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Implements feature request: https://github.com/Nike-Inc/gimme-aws-creds/issues/472

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR implements a feature enhancement to improve/simplify usability of the tool.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run locally with code changes in my forked repo

## Screenshots (if appropriate):
Here is what the prompt looks like:
![Prompt](https://github.com/user-attachments/assets/0badd275-4ed3-4142-96f1-e0ddb82d559d)

And here is the result:
![Result](https://github.com/user-attachments/assets/5dbd5de7-94da-42e3-b492-9431f102f74c)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
