### PR TITLE
Fix duo authorization without preferred device

### DIFF
--- a/gimme_aws_creds/duo_universal.py
+++ b/gimme_aws_creds/duo_universal.py
@@ -181,7 +181,8 @@ class OktaDuoUniversal:
 
     @staticmethod
     def _find_device_to_use(doc):
-        device = doc.find('.//input[@name="preferred_device"]').get('value')
+        preferred_device_block = doc.find('.//input[@name="preferred_device"]')
+        device = preferred_device_block.get('value') if preferred_device_block is not None else None
         if device is None or device == '':
             device = doc.find('.//select[@name="device"]/option').get('value')
         return device

--- a/tests/fixtures/duo_universal_login_form_with_empty_preferred_device.html
+++ b/tests/fixtures/duo_universal_login_form_with_empty_preferred_device.html
@@ -50,6 +50,9 @@
                     <input type="hidden" name="should_update_dm" value="False">
 
 
+                    <input type="hidden" name="preferred_factor" value="">
+                    <input type="hidden" name="preferred_device" value="">
+
                     <input type="hidden" name="days_to_block" value="None">
                     <input type="hidden" name="should_retry_u2f_timeouts" value="True">
 
@@ -64,7 +67,13 @@
                             <select name="device" aria-label="Device" tabindex=2>
 
 
-                                <option value="token">Token</option>
+                                <option value="phone1">Phone 1 &#x28;XXX-XXX-1111&#x29;</option>
+
+
+                                <option value="phone2">Phone 2 &#x28;XXX-XXX-2222&#x29;</option>
+
+
+                                <option value="phone3">Phone 3 &#x28;XXX-XXX-3333&#x29;</option>
 
 
                             </select>
@@ -74,20 +83,175 @@
 
                     <div id="auth_methods">
 
-                        <fieldset data-device-index="token" class="hidden">
-                        <div class="passcode-label row-label">
-                            <input type="hidden" name="factor" value="Passcode">
-                            <input type="hidden" name="has-token" value="true">
-                            <span class="label factor-label">
- <i class="icon-smartphone-ellipsis" alt="" role="presentation"></i>
- Enter a Passcode
- </span>
-                            <div class="passcode-input-wrapper">
-                                <input type="text" name="passcode" class="hidden" autocomplete="off" placeholder="&#x28;ex.&#x20;123456&#x29;" tabindex=2>
-                                </div>
-                            <button tabindex="2" type="submit" id="passcode" class="positive&#x20;auth-button" ><!-- -->Enter a Passcode </button>
+                        <fieldset data-device-index="phone1" class="hidden">
+                            <h2 class="medium-or-larger auth-method-header">
+                                Choose an authentication method
+                            </h2>
+
+
+                            <div class="row-label push-label">
+                                <input type="hidden" name="factor" value="Duo&#x20;Push">
+                                <span class="label factor-label">
+        <i class="icon-smartphone-check"></i>
+        Duo Push
+
+
+        <small class="used-automatically">
+        <i class="icon-check"></i>
+        Used automatically
+        </small>
+
+
+        </span>
+                                <button tabindex="2" type="submit" class="positive&#x20;auth-button"><!-- -->Send Me a
+                                    Push
+                                </button>
                             </div>
+
+
+                            <div class="row-label phone-label">
+                                <input type="hidden" name="factor" value="Phone&#x20;Call">
+                                <span class="label factor-label">
+        <i class="icon-call-ringing" alt="" role="presentation"></i>
+        Call Me
+
+        </span>
+                                <button tabindex="2" type="submit" class="positive&#x20;auth-button"><!-- -->Call Me
+                                </button>
+                            </div>
+
+                            <div class="passcode-label row-label">
+                                <input type="hidden" name="factor" value="Passcode">
+                                <span class="label factor-label">
+        <i class="icon-smartphone-ellipsis" alt="" role="presentation"></i>
+        Passcode
+        </span>
+                                <div class="passcode-input-wrapper">
+                                    <input type="text" name="passcode" autocomplete="off" data-index="phone1"
+                                           class="hidden passcode-input" placeholder="ex.&#x20;867539"
+                                           aria-label="passcode" tabindex=2>
+                                    <div class="next-passcode-msg" role="alert" aria-live="polite"></div>
+                                </div>
+                                <button tabindex="2" type="submit" id="passcode" class="positive&#x20;auth-button">
+                                    <!-- -->Enter a Passcode
+                                </button>
+                                <input name="phone-smsable" type="hidden" value="True"/>
+                                <input name="mobile-otpable" type="hidden" value="True"/>
+                                <input name="next-passcode" type="hidden" value="None"/>
+                            </div>
+
                         </fieldset>
+
+                        <fieldset data-device-index="phone2" class="hidden">
+                            <h2 class="medium-or-larger auth-method-header">
+                                Choose an authentication method
+                            </h2>
+
+
+                            <div class="row-label push-label">
+                                <input type="hidden" name="factor" value="Duo&#x20;Push">
+                                <span class="label factor-label">
+        <i class="icon-smartphone-check"></i>
+        Duo Push
+
+
+
+        </span>
+                                <button tabindex="2" type="submit" class="positive&#x20;auth-button"><!-- -->Send Me a
+                                    Push
+                                </button>
+                            </div>
+
+
+                            <div class="row-label phone-label">
+                                <input type="hidden" name="factor" value="Phone&#x20;Call">
+                                <span class="label factor-label">
+        <i class="icon-call-ringing" alt="" role="presentation"></i>
+        Call Me
+
+        </span>
+                                <button tabindex="2" type="submit" class="positive&#x20;auth-button"><!-- -->Call Me
+                                </button>
+                            </div>
+
+                            <div class="passcode-label row-label">
+                                <input type="hidden" name="factor" value="Passcode">
+                                <span class="label factor-label">
+        <i class="icon-smartphone-ellipsis" alt="" role="presentation"></i>
+        Passcode
+        </span>
+                                <div class="passcode-input-wrapper">
+                                    <input type="text" name="passcode" autocomplete="off" data-index="phone2"
+                                           class="hidden passcode-input" placeholder="ex.&#x20;867539"
+                                           aria-label="passcode" tabindex=2>
+                                    <div class="next-passcode-msg" role="alert" aria-live="polite"></div>
+                                </div>
+                                <button tabindex="2" type="submit" id="passcode" class="positive&#x20;auth-button">
+                                    <!-- -->Enter a Passcode
+                                </button>
+                                <input name="phone-smsable" type="hidden" value="True"/>
+                                <input name="mobile-otpable" type="hidden" value="True"/>
+                                <input name="next-passcode" type="hidden" value="None"/>
+                            </div>
+
+                        </fieldset>
+
+                        <fieldset data-device-index="phone3" class="hidden">
+                            <h2 class="medium-or-larger auth-method-header">
+                                Choose an authentication method
+                            </h2>
+
+
+                            <div class="row-label push-label">
+                                <input type="hidden" name="factor" value="Duo&#x20;Push">
+                                <span class="label factor-label">
+        <i class="icon-smartphone-check"></i>
+        Duo Push
+
+
+
+        </span>
+                                <button tabindex="2" type="submit" class="positive&#x20;auth-button"><!-- -->Send Me a
+                                    Push
+                                </button>
+                            </div>
+
+
+                            <div class="row-label phone-label">
+                                <input type="hidden" name="factor" value="Phone&#x20;Call">
+                                <span class="label factor-label">
+        <i class="icon-call-ringing" alt="" role="presentation"></i>
+        Call Me
+
+        </span>
+                                <button tabindex="2" type="submit" class="positive&#x20;auth-button"><!-- -->Call Me
+                                </button>
+                            </div>
+
+                            <div class="passcode-label row-label">
+                                <input type="hidden" name="factor" value="Passcode">
+                                <span class="label factor-label">
+        <i class="icon-smartphone-ellipsis" alt="" role="presentation"></i>
+        Passcode
+        </span>
+                                <div class="passcode-input-wrapper">
+                                    <input type="text" name="passcode" autocomplete="off" data-index="phone3"
+                                           class="hidden passcode-input" placeholder="ex.&#x20;867539"
+                                           aria-label="passcode" tabindex=2>
+                                    <div class="next-passcode-msg" role="alert" aria-live="polite"></div>
+                                </div>
+                                <button tabindex="2" type="submit" id="passcode" class="positive&#x20;auth-button">
+                                    <!-- -->Enter a Passcode
+                                </button>
+                                <input name="phone-smsable" type="hidden" value="True"/>
+                                <input name="mobile-otpable" type="hidden" value="True"/>
+                                <input name="next-passcode" type="hidden" value="None"/>
+                            </div>
+
+                        </fieldset>
+
+
+                        <input type="hidden" name="has-token" value="false">
 
 
                     </div>

--- a/tests/test_duo_universal_client.py
+++ b/tests/test_duo_universal_client.py
@@ -187,7 +187,21 @@ class TestDuoUniversalClient(unittest.TestCase):
             },
         }
 
-    def test_no_preferred_device(self):
+    def test_empty_preferred_device(self):
+        session = requests.Session()
+        login_form_response = Mock()
+        login_form_response.content = read_fixture('duo_universal_login_form_with_empty_preferred_device.html')
+        duo = OktaDuoUniversal(ui=MockUserInterface(),
+                               session=session,
+                               state_token=self.OKTA_STATE_TOKEN,
+                               okta_factor=self.OKTA_FACTOR,
+                               remember_device=True,
+                               duo_factor='Passcode',
+                               duo_passcode='12345')
+        form_action, form_data = duo._get_duo_universal_login_form_data(login_form_response)
+        assert form_data['device'] == 'phone1'
+
+    def test_without_preferred_device(self):
         session = requests.Session()
         login_form_response = Mock()
         login_form_response.content = read_fixture('duo_universal_login_form_without_preferred_device.html')
@@ -199,7 +213,7 @@ class TestDuoUniversalClient(unittest.TestCase):
                                duo_factor='Passcode',
                                duo_passcode='12345')
         form_action, form_data = duo._get_duo_universal_login_form_data(login_form_response)
-        assert form_data['device'] == 'phone1'
+        assert form_data['device'] == 'token'
 
     def configure_duo_responses(self, duo_factor, passcode=None):
         # Initial request to Okta to verify IDP factor


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes handling of the case when there is no `preferred_device` input in the duo login form.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Nike-Inc/gimme-aws-creds/issues/478

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes authorization for users with Duo hardware tokens.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test with a new fixture login-form that is based on the actual service response.
Tested the fixed case locally by running the tool.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
