### PR TITLE
fix: Update okta_classic.py to handle scenario when Okta MFA provider with factorType "push" may return no profiles

### DIFF
--- a/gimme_aws_creds/okta_classic.py
+++ b/gimme_aws_creds/okta_classic.py
@@ -920,7 +920,10 @@ class OktaClassicClient(object):
         if factor['provider'] == 'DUO':
             return factor['factorType'] + ": " + factor['provider'].capitalize()
         elif factor['factorType'] == 'push':
-            return "Okta Verify App: " + factor['profile']['deviceType'] + ": " + factor['profile']['name']
+            if 'profile' in factor:
+                return "Okta Verify App: " + factor['profile']['deviceType'] + ": " + factor['profile']['name']
+            else:
+                return "Okta Verify App - push verification"
         elif factor['factorType'] == 'sms':
             return factor['factorType'] + ": " + factor['profile']['phoneNumber']
         elif factor['factorType'] == 'email':

--- a/tests/test_okta_classic_client.py
+++ b/tests/test_okta_classic_client.py
@@ -1164,10 +1164,10 @@ class TestOktaClassicClient(unittest.TestCase):
         self.assertEqual(result, "Okta Verify App: SmartPhone_IPhone: Jane.Doe iPhone")
 
     def test_build_factor_name_push_without_profile(self):
-        """ Test building a display name for push"""
+        """ Test building a display name for push without profile key"""
         result = self.client._build_factor_name(self.push_factor_without_profile)
         self.assertEqual(result, "Okta Verify App - push verification")
-        
+
     def test_build_factor_name_totp(self):
         """ Test building a display name for TOTP"""
         result = self.client._build_factor_name(self.totp_factor)

--- a/tests/test_okta_classic_client.py
+++ b/tests/test_okta_classic_client.py
@@ -81,6 +81,23 @@ class TestOktaClassicClient(unittest.TestCase):
             }
         }
 
+        self.push_factor_without_profile = {
+                "id": "opf9ei43pbAgb2qgc0h7",
+                "factorType": "push",
+                "provider": "OKTA",
+                "vendorName": "OKTA",
+                "_links": {
+                    "verify": {
+                        "href": "https://example.okta.com/api/v1/authn/factors/opf9ei43pbAgb2qgc0h7/verify",
+                        "hints": {
+                            "allow": [
+                                "POST"
+                            ]
+                        }
+                    }
+                }
+            }
+        
         self.push_factor = {
                 "id": "opf9ei43pbAgb2qgc0h7",
                 "factorType": "push",
@@ -1146,6 +1163,11 @@ class TestOktaClassicClient(unittest.TestCase):
         result = self.client._build_factor_name(self.push_factor)
         self.assertEqual(result, "Okta Verify App: SmartPhone_IPhone: Jane.Doe iPhone")
 
+    def test_build_factor_name_push_without_profile(self):
+        """ Test building a display name for push"""
+        result = self.client._build_factor_name(self.push_factor_without_profile)
+        self.assertEqual(result, "Okta Verify App - push verification")
+        
     def test_build_factor_name_totp(self):
         """ Test building a display name for TOTP"""
         result = self.client._build_factor_name(self.totp_factor)


### PR DESCRIPTION
Addressing possible case when Okta Verify App doesn't return a 'profile' attribute in the factor definition

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR addresses issue #496 by adding additional logic to test for the case when the Okta MFA provider of factorType 'push' is missing 'profile' attribute in factor.

It was discovered that the contents of the Okta 'push' factorType can be missing the 'profile' attribute. This causes the _build_factor_name method to error out with `KeyError: 'profile'`.

To fix this, this PR adds additional logic to test for the presence of the 'profile' attribute, in the factor array, and output accordingly.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This PR fixes https://github.com/Nike-Inc/gimme-aws-creds/issues/496

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fixes a break that affects users who choose to rely on `force_classic` to receive push notifications.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested by running `gimme-aws-creds` locally, which causes the application to run to completion. Running pytest also indicates that the changes do not introduce regression.

## Screenshots (if appropriate):

Below is a screenshot of the dictionary of the Okta provider with a factorType of 'push' which lacks a "profile" attribute in its dict.

<img width="637" height="609" alt="okta-redacted" src="https://github.com/user-attachments/assets/9f771da3-7c27-4fe8-92fb-c5fbba7fc5ae" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.
