### PR TITLE
Add a flag to allow us to override the aws credentials profile that the credentials are saved under. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ A configuration wizard will prompt you to enter the necessary configuration para
   - 'internal' for direct interaction with the Okta APIs (`OKTA_API_KEY` environment variable required)
   - 'appurl' to set an aws application link url. This setting removes the need of an OKTA API key.
 - write_aws_creds - True or False - If True, the AWS credentials will be written to `~/.aws/credentials` otherwise it will be written to stdout.
-- cred_profile - If writing to the AWS cred file, this sets the name of the AWS credential profile.
+- cred_profile - If writing to the AWS cred file, this sets the name of the AWS credential profile. Can be overridden with the --aws-cred-profile CLI option or the GIMME_AWS_CREDS_CRED_PROFILE environment variable.
   - The reserved word `role` will use the name component of the role arn as the profile name. i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [okta-1234-role] in the aws credentials file
   - The reserved word `acc` will use the account number (or alias if `resolve_aws_alias` is set to y) as the profile name. i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [arn:aws:iam::123456789012] or if `resolve_aws_alias` [okta-1234-role] in the aws credentials file.
   - The reserved word `acc-role` will use the name component of the role arn prepended with account number (or alias if `resolve_aws_alias` is set to y) to avoid collisions, i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [123456789012-okta-1234-role], or if `resolve_aws_alias` [okta-1234-role] in the aws credentials file
@@ -320,7 +320,7 @@ A list of values of to change with environment variables are:
 - `AWS_DEFAULT_DURATION` - corresponds to `aws_default_duration` configuration
 - `AWS_SHARED_CREDENTIALS_FILE` - file to write credentials to, points to `~/.aws/credentials` by default
 - `GIMME_AWS_CREDS_CLIENT_ID` - corresponds to `client_id` configuration
-- `GIMME_AWS_CREDS_CRED_PROFILE` - corresponds to `cred_profile` configuration
+- `GIMME_AWS_CREDS_CRED_PROFILE` - corresponds to `cred_profile` configuration and `--aws-cred-profile` CLI option
 - `GIMME_AWS_CREDS_OUTPUT_FORMAT` - corresponds to `output_format` configuration and `--output-format` CLI option
 - `OKTA_AUTH_SERVER` - corresponds to `okta_auth_server` configuration
 - `OKTA_DEVICE_TOKEN` - corresponds to `device_token` configuration, can be used in CI

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -161,6 +161,11 @@ class Config(object):
             '--force-classic', action='store_true',
             help='Force the use of the Okta Classic login process (Okta Identity Engine only)'
         )
+        parser.add_argument(
+            '--aws-cred-profile',
+            help="If set, overrides the cred_profile setting from the config file and the "
+                 "GIMME_AWS_CREDS_CRED_PROFILE environment variable."
+        )
         args = parser.parse_args(self.ui.args)
 
         self.action_configure = args.action_configure
@@ -192,6 +197,7 @@ class Config(object):
             self.output_format = args.output_format
         if args.roles is not None:
             self.roles = [role.strip() for role in args.roles.split(',') if role.strip()]
+        self.cred_profile = args.aws_cred_profile
         self.conf_profile = args.profile or 'DEFAULT'
 
     def _handle_config(self, config, profile_config, include_inherits = True):

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -475,6 +475,9 @@ class GimmeAWSCreds(object):
                 key = self.envvar_conf_map.get(value, value).lower()
                 self.conf_dict[key] = self.ui.environ.get(value)
 
+        if config.cred_profile is not None:
+            self.conf_dict['cred_profile'] = config.cred_profile
+
         # AWS Default session duration ....
         if self.conf_dict.get('aws_default_duration'):
             self.config.aws_default_duration = int(self.conf_dict['aws_default_duration'])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,6 +31,7 @@ class TestConfig(unittest.TestCase):
             remember_device=False,
             output_format=None,
             roles=None,
+            aws_cred_profile=None,
             action_register_device=False,
             action_configure=False,
             action_list_profiles=False,
@@ -46,6 +47,22 @@ class TestConfig(unittest.TestCase):
         """Test to make sure username gets returned"""
         self.config.get_args()
         self.assertEqual(self.config.username, "ann")
+
+    def test_get_args_aws_cred_profile_set(self):
+        """Test that --aws-cred-profile is stored on Config when provided"""
+        test_ui = MockUserInterface(argv=[
+            'gimme-aws-creds', '--aws-cred-profile', 'my-custom-profile',
+        ])
+        config = Config(gac_ui=test_ui, create_config=False)
+        config.get_args()
+        self.assertEqual(config.cred_profile, "my-custom-profile")
+
+    def test_get_args_aws_cred_profile_not_set(self):
+        """Test that cred_profile is None on Config when --aws-cred-profile is not provided"""
+        test_ui = MockUserInterface(argv=['gimme-aws-creds'])
+        config = Config(gac_ui=test_ui, create_config=False)
+        config.get_args()
+        self.assertIsNone(config.cred_profile)
 
     def test_read_config(self):
         """Test to make sure getting config works"""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,11 @@
+import shutil
 import unittest
 from unittest.mock import patch
 
 from gimme_aws_creds import errors
 from gimme_aws_creds.common import RoleSet
 from gimme_aws_creds.main import GimmeAWSCreds
+from tests.user_interface_mock import MockUserInterface
 
 
 class TestMain(unittest.TestCase):
@@ -312,3 +314,70 @@ class TestMain(unittest.TestCase):
         include_path = True
         self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
                          'foo')
+
+
+class TestCredProfilePrecedence(unittest.TestCase):
+    """Tests for --aws-cred-profile CLI flag precedence over env var and config file.
+
+    Expected precedence: CLI flag > env var > config file
+    """
+
+    CONFIG_TEMPLATE = """[DEFAULT]
+client_id = test-client
+okta_org_url = https://test.okta.com
+cred_profile = {cred_profile}
+"""
+
+    def setUp(self):
+        self._temp_dirs = []
+
+    def tearDown(self):
+        for d in self._temp_dirs:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def _build_and_generate(self, argv=None, environ=None, config_cred_profile='file-profile'):
+        test_ui = MockUserInterface(
+            argv=argv or [],
+            environ=environ or {},
+        )
+        self._temp_dirs.append(test_ui.HOME)
+        with open(test_ui.HOME + "/.okta_aws_login_config", "w") as f:
+            f.write(self.CONFIG_TEMPLATE.format(cred_profile=config_cred_profile))
+
+        creds = GimmeAWSCreds(ui=test_ui)
+        creds.generate_config()
+        return creds
+
+    def test_cli_flag_overrides_config_file(self):
+        """--aws-cred-profile should override the cred_profile from config file"""
+        creds = self._build_and_generate(
+            argv=['gimme-aws-creds', '--aws-cred-profile', 'cli-profile'],
+            config_cred_profile='file-profile',
+        )
+        self.assertEqual(creds.conf_dict['cred_profile'], 'cli-profile')
+
+    def test_cli_flag_overrides_env_var(self):
+        """--aws-cred-profile should override GIMME_AWS_CREDS_CRED_PROFILE env var"""
+        creds = self._build_and_generate(
+            argv=['gimme-aws-creds', '--aws-cred-profile', 'cli-profile'],
+            environ={'GIMME_AWS_CREDS_CRED_PROFILE': 'env-profile'},
+            config_cred_profile='file-profile',
+        )
+        self.assertEqual(creds.conf_dict['cred_profile'], 'cli-profile')
+
+    def test_env_var_overrides_config_file_when_no_cli_flag(self):
+        """Without --aws-cred-profile, GIMME_AWS_CREDS_CRED_PROFILE should override config file"""
+        creds = self._build_and_generate(
+            argv=['gimme-aws-creds'],
+            environ={'GIMME_AWS_CREDS_CRED_PROFILE': 'env-profile'},
+            config_cred_profile='file-profile',
+        )
+        self.assertEqual(creds.conf_dict['cred_profile'], 'env-profile')
+
+    def test_config_file_used_when_no_cli_flag_or_env_var(self):
+        """Without --aws-cred-profile or env var, config file value should be used"""
+        creds = self._build_and_generate(
+            argv=['gimme-aws-creds'],
+            config_cred_profile='file-profile',
+        )
+        self.assertEqual(creds.conf_dict['cred_profile'], 'file-profile')


### PR DESCRIPTION
## Description
Currently we allow the AWS profile name the credentials will be saved under via the configuration file (either per profile or via inheritance) or via a environment variable. This PR adds a feature flag that will allow users to specify `--aws-cred-profile <profile name>`. This flag would take precedence and override both the environment variable if set and the profile from the configuration file. This allows tooling to standardize profile names even if a user has a profile specified that they prefer for use outside of that tooling. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Nike-Inc/gimme-aws-creds/issues/499
## Motivation and Context
The `cred_profile` setting can currently be set via the config file or the `GIMME_AWS_CREDS_CRED_PROFILE` environment variable, but there is no CLI flag to override it per-invocation. This is inconsistent with other settings like `output_format`, which supports all three layers: config file, environment variable (`GIMME_AWS_CREDS_OUTPUT_FORMAT`), and CLI flag (`--output-format`).
A CLI flag is useful when switching credential profile strategies on the fly — for example, writing to a specific named profile for a one-off script or CI job without modifying the config file or polluting the shell environment.


## How Has This Been Tested?
- **Unit tests for argument parsing** (`tests/test_config.py`): Verifies that `--aws-cred-profile` is correctly parsed and stored on the `Config` object, and that it defaults to `None` when not provided.
- **Integration tests for precedence** (`tests/test_main.py::TestCredProfilePrecedence`): Exercises the full `generate_config()` flow with a real config file, environment variables, and CLI arguments to verify the override chain:
  - CLI flag overrides config file value
  - CLI flag overrides environment variable
  - Environment variable overrides config file when no CLI flag is set
  - Config file value is used when neither CLI flag nor environment variable is set
- Existing tests updated to include the new `aws_cred_profile` argument in mocked `Namespace` objects so they continue to pass.
- All existing tests pass without modification.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
