### PR TITLE
feat(okta-classic): pin MFA factor via preferred_mfa_factor_id

### DIFF
--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -259,6 +259,7 @@ class Config(object):
                 okta_username = Okta username
                 aws_default_duration = Default AWS session duration (3600)
                 preferred_mfa_type = Select this MFA device type automatically
+                preferred_mfa_factor_id = Pin a specific Okta factor by id (overrides preferred_mfa_type when matched)
                 include_path - (optional) includes that full role path to the role name for profile
                 enable_keychain = (optional) enable the use of the system keychain to store the user's password
 
@@ -281,6 +282,7 @@ class Config(object):
             'resolve_aws_alias': 'n',
             'include_path': 'n',
             'preferred_mfa_type': '',
+            'preferred_mfa_factor_id': '',
             'remember_device': 'n',
             'aws_default_duration': '3600',
             'output_format': 'export',

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -597,6 +597,9 @@ class GimmeAWSCreds(object):
             if self.conf_dict.get('preferred_mfa_provider'):
                 okta.set_preferred_mfa_provider(self.conf_dict['preferred_mfa_provider'])
 
+            if self.conf_dict.get('preferred_mfa_factor_id'):
+                okta.set_preferred_mfa_factor_id(self.conf_dict['preferred_mfa_factor_id'])
+
             if self.conf_dict.get('duo_universal_factor'):
                 okta.set_duo_universal_factor(self.conf_dict.get('duo_universal_factor'))
 

--- a/gimme_aws_creds/okta_classic.py
+++ b/gimme_aws_creds/okta_classic.py
@@ -75,6 +75,7 @@ class OktaClassicClient(object):
         self._password = None
         self._preferred_mfa_type = None
         self._preferred_mfa_provider = None
+        self._preferred_mfa_factor_id = None
         self._duo_universal_factor = 'Duo Push'
         self._mfa_code = None
         self._remember_device = None
@@ -117,6 +118,9 @@ class OktaClassicClient(object):
 
     def set_preferred_mfa_provider(self, preferred_mfa_provider):
         self._preferred_mfa_provider = preferred_mfa_provider
+
+    def set_preferred_mfa_factor_id(self, preferred_mfa_factor_id):
+        self._preferred_mfa_factor_id = preferred_mfa_factor_id
 
     def set_mfa_code(self, mfa_code):
         self._mfa_code = mfa_code
@@ -872,6 +876,21 @@ class OktaClassicClient(object):
             else:
                 preferred_factors = preferred_factors_with_preferred_provider
 
+        # Pin to a specific factor by its Okta factor id. Overrides the type/provider
+        # filters above when matched, since the id uniquely identifies one factor.
+        if self._preferred_mfa_factor_id is not None:
+            factor_id_matches = [item for item in factors if item.get('id') == self._preferred_mfa_factor_id]
+            if factor_id_matches:
+                preferred_factors = factor_id_matches
+            else:
+                available = ', '.join(
+                    '{} ({})'.format(item.get('id'), self._build_factor_name(item))
+                    for item in factors
+                )
+                self.ui.notify('Preferred factor id of {} not available. Available factor ids: {}'.format(
+                    self._preferred_mfa_factor_id, available
+                ))
+
         if len(preferred_factors) == 1:
             factor_name = self._build_factor_name(preferred_factors[0])
             self.ui.info(factor_name + ' selected')
@@ -886,7 +905,7 @@ class OktaClassicClient(object):
             for i, factor in enumerate(factors):
                 factor_name = self._build_factor_name(factor)
                 if factor_name != "":
-                    self.ui.info('[{}] {}'.format(i, factor_name))
+                    self.ui.info('[{}] {} (id: {})'.format(i, factor_name, factor.get('id')))
             selection = self._get_user_int_factor_choice(len(factors))
 
         # make sure the choice is valid

--- a/tests/test_okta_classic_client.py
+++ b/tests/test_okta_classic_client.py
@@ -1148,6 +1148,26 @@ class TestOktaClassicClient(unittest.TestCase):
         with self.assertRaises(errors.GimmeAWSCredsExitBase):
             result = self.client._choose_factor(self.factor_list)
 
+    def test_choose_factor_pinned_by_id(self):
+        """Pinning preferred_mfa_factor_id auto-selects the matching factor without prompting"""
+        self.client.set_preferred_mfa_factor_id(self.webauthn_factor['id'])
+        result = self.client._choose_factor(self.factor_list)
+        self.assertEqual(result, self.webauthn_factor)
+
+    @patch('builtins.input', return_value='0')
+    def test_choose_factor_pinned_by_id_miss_falls_back_to_prompt(self, mock_input):
+        """An unmatched factor id falls through to the interactive picker rather than failing"""
+        self.client.set_preferred_mfa_factor_id('no_such_factor_id')
+        result = self.client._choose_factor(self.factor_list)
+        self.assertEqual(result, self.sms_factor)
+
+    def test_choose_factor_pinned_by_id_overrides_type(self):
+        """A pinned factor id wins over preferred_mfa_type when both are set"""
+        self.client.set_preferred_mfa_type('push')
+        self.client.set_preferred_mfa_factor_id(self.webauthn_factor['id'])
+        result = self.client._choose_factor(self.factor_list)
+        self.assertEqual(result, self.webauthn_factor)
+
     def test_build_factor_name_sms(self):
         """ Test building a display name for SMS"""
         result = self.client._build_factor_name(self.sms_factor)


### PR DESCRIPTION
preferred_mfa_type narrows to a factor type but leaves the sub-picker visible when multiple factors share that type (e.g. several webauthn authenticators enrolled at Okta). Add a new config key preferred_mfa_factor_id that pins one factor by its Okta id, applied after the existing type/provider filters and overriding them when matched. On miss, lists the available ids and falls through to the interactive picker. Factor ids are now also printed alongside each choice in the picker so users can discover the id to pin.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
