### PR TITLE
feat: pin MFA factor via preferred_mfa_factor_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ A configuration wizard will prompt you to enter the necessary configuration para
   - GOOGLE
   - OKTA
   - DUO
+- preferred_mfa_factor_id - (optional) pin a specific MFA factor by its Okta factor id. Useful when multiple factors of the same type are enrolled (e.g. several webauthn authenticators such as Touch ID, iCloud Keychain, YubiKey) and `preferred_mfa_type` is not narrow enough to skip the picker. Overrides `preferred_mfa_type` and `preferred_mfa_provider` when matched. If the id is not present in Okta's factor list, the available ids are listed and the interactive picker is shown. To discover ids, run gimme-aws-creds once: the picker prints each factor's id alongside its name.
 - duo_universal_factor - (optional) Configure which type of factor to use with Duo Universal Prompt. Must be one of (case-sensitive):
   - `Duo Push` (default)
   - `Passcode`

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -259,6 +259,7 @@ class Config(object):
                 okta_username = Okta username
                 aws_default_duration = Default AWS session duration (3600)
                 preferred_mfa_type = Select this MFA device type automatically
+                preferred_mfa_factor_id = Pin a specific Okta factor by id (overrides preferred_mfa_type when matched)
                 include_path - (optional) includes that full role path to the role name for profile
                 enable_keychain = (optional) enable the use of the system keychain to store the user's password
 
@@ -281,6 +282,7 @@ class Config(object):
             'resolve_aws_alias': 'n',
             'include_path': 'n',
             'preferred_mfa_type': '',
+            'preferred_mfa_factor_id': '',
             'remember_device': 'n',
             'aws_default_duration': '3600',
             'output_format': 'export',

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -597,6 +597,9 @@ class GimmeAWSCreds(object):
             if self.conf_dict.get('preferred_mfa_provider'):
                 okta.set_preferred_mfa_provider(self.conf_dict['preferred_mfa_provider'])
 
+            if self.conf_dict.get('preferred_mfa_factor_id'):
+                okta.set_preferred_mfa_factor_id(self.conf_dict['preferred_mfa_factor_id'])
+
             if self.conf_dict.get('duo_universal_factor'):
                 okta.set_duo_universal_factor(self.conf_dict.get('duo_universal_factor'))
 

--- a/gimme_aws_creds/okta_classic.py
+++ b/gimme_aws_creds/okta_classic.py
@@ -75,6 +75,7 @@ class OktaClassicClient(object):
         self._password = None
         self._preferred_mfa_type = None
         self._preferred_mfa_provider = None
+        self._preferred_mfa_factor_id = None
         self._duo_universal_factor = 'Duo Push'
         self._mfa_code = None
         self._remember_device = None
@@ -117,6 +118,9 @@ class OktaClassicClient(object):
 
     def set_preferred_mfa_provider(self, preferred_mfa_provider):
         self._preferred_mfa_provider = preferred_mfa_provider
+
+    def set_preferred_mfa_factor_id(self, preferred_mfa_factor_id):
+        self._preferred_mfa_factor_id = preferred_mfa_factor_id
 
     def set_mfa_code(self, mfa_code):
         self._mfa_code = mfa_code
@@ -872,6 +876,21 @@ class OktaClassicClient(object):
             else:
                 preferred_factors = preferred_factors_with_preferred_provider
 
+        # Pin to a specific factor by its Okta factor id. Overrides the type/provider
+        # filters above when matched, since the id uniquely identifies one factor.
+        if self._preferred_mfa_factor_id is not None:
+            factor_id_matches = [item for item in factors if item.get('id') == self._preferred_mfa_factor_id]
+            if factor_id_matches:
+                preferred_factors = factor_id_matches
+            else:
+                available = ', '.join(
+                    '{} ({})'.format(item.get('id'), self._build_factor_name(item))
+                    for item in factors
+                )
+                self.ui.notify('Preferred factor id of {} not available. Available factor ids: {}'.format(
+                    self._preferred_mfa_factor_id, available
+                ))
+
         if len(preferred_factors) == 1:
             factor_name = self._build_factor_name(preferred_factors[0])
             self.ui.info(factor_name + ' selected')
@@ -886,7 +905,7 @@ class OktaClassicClient(object):
             for i, factor in enumerate(factors):
                 factor_name = self._build_factor_name(factor)
                 if factor_name != "":
-                    self.ui.info('[{}] {}'.format(i, factor_name))
+                    self.ui.info('[{}] {} (id: {})'.format(i, factor_name, factor.get('id')))
             selection = self._get_user_int_factor_choice(len(factors))
 
         # make sure the choice is valid

--- a/gimme_aws_creds/okta_classic.py
+++ b/gimme_aws_creds/okta_classic.py
@@ -883,12 +883,8 @@ class OktaClassicClient(object):
             if factor_id_matches:
                 preferred_factors = factor_id_matches
             else:
-                available = ', '.join(
-                    '{} ({})'.format(item.get('id'), self._build_factor_name(item))
-                    for item in factors
-                )
-                self.ui.notify('Preferred factor id of {} not available. Available factor ids: {}'.format(
-                    self._preferred_mfa_factor_id, available
+                self.ui.notify('Preferred factor id {!r} not found among {} enrolled factors.'.format(
+                    self._preferred_mfa_factor_id, len(factors)
                 ))
 
         if len(preferred_factors) == 1:

--- a/tests/test_okta_classic_client.py
+++ b/tests/test_okta_classic_client.py
@@ -1148,6 +1148,26 @@ class TestOktaClassicClient(unittest.TestCase):
         with self.assertRaises(errors.GimmeAWSCredsExitBase):
             result = self.client._choose_factor(self.factor_list)
 
+    def test_choose_factor_pinned_by_id(self):
+        """Pinning preferred_mfa_factor_id auto-selects the matching factor without prompting"""
+        self.client.set_preferred_mfa_factor_id(self.webauthn_factor['id'])
+        result = self.client._choose_factor(self.factor_list)
+        self.assertEqual(result, self.webauthn_factor)
+
+    @patch('builtins.input', return_value='0')
+    def test_choose_factor_pinned_by_id_miss_falls_back_to_prompt(self, mock_input):
+        """An unmatched factor id falls through to the interactive picker rather than failing"""
+        self.client.set_preferred_mfa_factor_id('no_such_factor_id')
+        result = self.client._choose_factor(self.factor_list)
+        self.assertEqual(result, self.sms_factor)
+
+    def test_choose_factor_pinned_by_id_overrides_type(self):
+        """A pinned factor id wins over preferred_mfa_type when both are set"""
+        self.client.set_preferred_mfa_type('push')
+        self.client.set_preferred_mfa_factor_id(self.webauthn_factor['id'])
+        result = self.client._choose_factor(self.factor_list)
+        self.assertEqual(result, self.webauthn_factor)
+
     def test_build_factor_name_sms(self):
         """ Test building a display name for SMS"""
         result = self.client._build_factor_name(self.sms_factor)


### PR DESCRIPTION
## Description

Adds optional `preferred_mfa_factor_id` config key that pins a specific MFA factor by Okta's stable factor id. Applied after `preferred_mfa_type` / `preferred_mfa_provider` in the existing filter chain in `_choose_factor`; on miss, falls through to the interactive picker (same notify-and-fall-through pattern the existing two filters use). The picker output now prints the factor id alongside the display name so the id is discoverable in-place.

Classic only — Okta Identity Engine delegates MFA to the browser device-code flow and has no analogous picker.

## Related Issue

Fixes #491.

## Motivation and Context

`preferred_mfa_type` narrows by factor type (`webauthn`, `push`, `token:software:totp`, etc.) but can't pin a specific instance within a type. With multiple webauthn authenticators enrolled at Okta (Touch ID, iCloud Keychain, password managers, hardware keys), the sub-picker still appears on every run. Existing workarounds — typing the index each time, or deregistering unused authenticators at Okta (affects all Okta logins, not just AWS) — are both poor.

Compared to the OP's name-based `preferred_webauthn`, an id-based key works across all factor types and avoids fragile name matching when two devices share a label.

## How Has This Been Tested?

- New unit tests in `tests/test_okta_classic_client.py` covering: pin-hit auto-select, pin-miss fall-through to picker, pin overrides `preferred_mfa_type` when both are set.
- Full suite passes (95/95).
- Manual smoke against a personal Okta tenant with multiple webauthn authenticators enrolled: picker prints the factor id; pinning a specific id skips the sub-picker on subsequent runs.

## Screenshots (if appropriate):

N/A — CLI behavior change.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.